### PR TITLE
Add delay to each acceptance test step.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,4 +70,28 @@ pipeline {
             }
         }
     }
+    post {
+        success {
+            script {
+                if (currentBuild.getBuildCauses('hudson.triggers.TimerTrigger$TimerTriggerCause').size() > 0) {
+                    slackSend(
+                        channel: '#terraform-provider-development',
+                        color: 'good',
+                        message: "The pipeline ${currentBuild.fullDisplayName} succeeded (runtime: ${currentBuild.durationString.minus(' and counting')})\n${currentBuild.absoluteUrl}"
+                    )
+                }
+            }
+        }
+        failure {
+            script {
+                if (currentBuild.getBuildCauses('hudson.triggers.TimerTrigger$TimerTriggerCause').size() > 0) {
+                    slackSend(
+                        channel: '#terraform-provider-development',
+                        color: 'danger',
+                        message: "The pipeline ${currentBuild.fullDisplayName} failed (runtime: ${currentBuild.durationString.minus(' and counting')})\n${currentBuild.absoluteUrl}"
+                    )
+                }
+            }
+        }
+    }
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -14,6 +15,13 @@ var providerFactories = map[string]func() (*schema.Provider, error){
 	"polaris": func() (*schema.Provider, error) {
 		return Provider(), nil
 	},
+}
+
+// testStepDelay is the idle time between each test step. Executing the test
+// steps too fast in succession causes the auth service to respond with status
+// code 503.
+var testStepDelay = func() {
+	time.Sleep(5 * time.Second)
 }
 
 // testConfig holds the configuration for a test, i.e. the actaul values to

--- a/internal/provider/resource_aws_account_test.go
+++ b/internal/provider/resource_aws_account_test.go
@@ -54,7 +54,8 @@ func TestAccPolarisAWSAccount_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			Config: accountOneRegion,
+			PreConfig: testStepDelay,
+			Config:    accountOneRegion,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "name", account.AccountName),
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "profile", account.Profile),
@@ -62,7 +63,8 @@ func TestAccPolarisAWSAccount_basic(t *testing.T) {
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "delete_snapshots_on_destroy", "false"),
 			),
 		}, {
-			Config: accountTwoRegions,
+			PreConfig: testStepDelay,
+			Config:    accountTwoRegions,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "name", account.AccountName),
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "profile", account.Profile),
@@ -71,7 +73,8 @@ func TestAccPolarisAWSAccount_basic(t *testing.T) {
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "delete_snapshots_on_destroy", "false"),
 			),
 		}, {
-			Config: accountOneRegion,
+			PreConfig: testStepDelay,
+			Config:    accountOneRegion,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "name", account.AccountName),
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "profile", account.Profile),

--- a/internal/provider/resource_aws_exocompute_test.go
+++ b/internal/provider/resource_aws_exocompute_test.go
@@ -52,7 +52,8 @@ func TestAccPolarisAWSExocompute_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			Config: exocompute,
+			PreConfig: testStepDelay,
+			Config:    exocompute,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "name", account.AccountName),
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "profile", account.Profile),

--- a/internal/provider/resource_azure_exocompute_test.go
+++ b/internal/provider/resource_azure_exocompute_test.go
@@ -53,7 +53,8 @@ func TestAccPolarisAzureExocompute_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			Config: exocompute,
+			PreConfig: testStepDelay,
+			Config:    exocompute,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_id", subscription.SubscriptionID),
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_name", subscription.SubscriptionName),

--- a/internal/provider/resource_azure_service_principal_test.go
+++ b/internal/provider/resource_azure_service_principal_test.go
@@ -44,7 +44,8 @@ func TestAccPolarisAzureServicePrincipal_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			Config: servicePrincipal,
+			PreConfig: testStepDelay,
+			Config:    servicePrincipal,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_azure_service_principal.default", "id", subscription.PrincipalID),
 				resource.TestCheckResourceAttr("polaris_azure_service_principal.default", "credentials", subscription.Credentials),
@@ -65,7 +66,8 @@ func TestAccPolarisAzureServicePrincipal_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			Config: servicePrincipal,
+			PreConfig: testStepDelay,
+			Config:    servicePrincipal,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_azure_service_principal.default", "id", subscription.PrincipalID),
 				resource.TestCheckResourceAttr("polaris_azure_service_principal.default", "app_id", subscription.PrincipalID),

--- a/internal/provider/resource_azure_subscription_test.go
+++ b/internal/provider/resource_azure_subscription_test.go
@@ -68,7 +68,8 @@ func TestAccPolarisAzureSubscription_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			Config: subscriptionOneRegion,
+			PreConfig: testStepDelay,
+			Config:    subscriptionOneRegion,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_id", subscription.SubscriptionID),
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_name", subscription.SubscriptionName),
@@ -77,7 +78,8 @@ func TestAccPolarisAzureSubscription_basic(t *testing.T) {
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "delete_snapshots_on_destroy", "false"),
 			),
 		}, {
-			Config: subscriptionTwoRegions,
+			PreConfig: testStepDelay,
+			Config:    subscriptionTwoRegions,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_id", subscription.SubscriptionID),
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_name", subscription.SubscriptionName),
@@ -87,7 +89,8 @@ func TestAccPolarisAzureSubscription_basic(t *testing.T) {
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "delete_snapshots_on_destroy", "false"),
 			),
 		}, {
-			Config: subscriptionOneRegion,
+			PreConfig: testStepDelay,
+			Config:    subscriptionOneRegion,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_id", subscription.SubscriptionID),
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_name", subscription.SubscriptionName),

--- a/internal/provider/resource_gcp_project_test.go
+++ b/internal/provider/resource_gcp_project_test.go
@@ -51,7 +51,8 @@ func TestAccPolarisGCPProject_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			Config: projectCredentials,
+			PreConfig: testStepDelay,
+			Config:    projectCredentials,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_gcp_project.default", "credentials", project.Credentials),
 				resource.TestCheckResourceAttr("polaris_gcp_project.default", "project", project.ProjectID),
@@ -71,7 +72,8 @@ func TestAccPolarisGCPProject_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			Config: projectValues,
+			PreConfig: testStepDelay,
+			Config:    projectValues,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_gcp_project.default", "project", project.ProjectID),
 				resource.TestCheckResourceAttr("polaris_gcp_project.default", "project_name", project.ProjectName),

--- a/internal/provider/resource_gcp_service_account_test.go
+++ b/internal/provider/resource_gcp_service_account_test.go
@@ -35,7 +35,8 @@ func TestAccPolarisGCPServiceAccount_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			Config: serviceAccount,
+			PreConfig: testStepDelay,
+			Config:    serviceAccount,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_gcp_service_account.default", "id", id),
 				resource.TestCheckResourceAttr("polaris_gcp_service_account.default", "credentials", project.Credentials),


### PR DESCRIPTION
Running the test steps in too quick succession causes the auth service
to respond with status code 503.