### PR TITLE
Increase wait time between tests to 10 seconds

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -21,7 +21,7 @@ var providerFactories = map[string]func() (*schema.Provider, error){
 // steps too fast in succession causes the auth service to respond with status
 // code 503.
 var testStepDelay = func() {
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 }
 
 // testConfig holds the configuration for a test, i.e. the actaul values to


### PR DESCRIPTION
If the tests are run to quickly in succession they are throttled by the
authentication service. This causes the tests to fail.