### PR TITLE
Reuse polaris provider in tests

### DIFF
--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -6,22 +6,16 @@ import (
 	"os"
 	"strings"
 	"text/template"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+var provider *schema.Provider = Provider()
+
 var providerFactories = map[string]func() (*schema.Provider, error){
 	"polaris": func() (*schema.Provider, error) {
-		return Provider(), nil
+		return provider, nil
 	},
-}
-
-// testStepDelay is the idle time between each test step. Executing the test
-// steps too fast in succession causes the auth service to respond with status
-// code 503.
-var testStepDelay = func() {
-	time.Sleep(10 * time.Second)
 }
 
 // testConfig holds the configuration for a test, i.e. the actaul values to

--- a/internal/provider/resource_aws_account_test.go
+++ b/internal/provider/resource_aws_account_test.go
@@ -60,8 +60,7 @@ func TestAccPolarisAWSAccount_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			PreConfig: testStepDelay,
-			Config:    accountOneRegion,
+			Config: accountOneRegion,
 			Check: resource.ComposeTestCheckFunc(
 				// Account resource
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "name", account.AccountName),
@@ -74,8 +73,7 @@ func TestAccPolarisAWSAccount_basic(t *testing.T) {
 				resource.TestCheckTypeSetElemAttr("polaris_aws_account.default", "cloud_native_protection.0.regions.*", "us-east-2"),
 			),
 		}, {
-			PreConfig: testStepDelay,
-			Config:    accountTwoRegions,
+			Config: accountTwoRegions,
 			Check: resource.ComposeTestCheckFunc(
 				// Account resource
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "name", account.AccountName),
@@ -89,8 +87,7 @@ func TestAccPolarisAWSAccount_basic(t *testing.T) {
 				resource.TestCheckTypeSetElemAttr("polaris_aws_account.default", "cloud_native_protection.0.regions.*", "us-west-2"),
 			),
 		}, {
-			PreConfig: testStepDelay,
-			Config:    accountOneRegion,
+			Config: accountOneRegion,
 			Check: resource.ComposeTestCheckFunc(
 				// Account resource
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "name", account.AccountName),

--- a/internal/provider/resource_aws_exocompute_test.go
+++ b/internal/provider/resource_aws_exocompute_test.go
@@ -55,8 +55,7 @@ func TestAccPolarisAWSExocompute_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			PreConfig: testStepDelay,
-			Config:    exocompute,
+			Config: exocompute,
 			Check: resource.ComposeTestCheckFunc(
 				// Account resource
 				resource.TestCheckResourceAttr("polaris_aws_account.default", "name", account.AccountName),

--- a/internal/provider/resource_azure_exocompute_test.go
+++ b/internal/provider/resource_azure_exocompute_test.go
@@ -57,8 +57,7 @@ func TestAccPolarisAzureExocompute_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			PreConfig: testStepDelay,
-			Config:    exocompute,
+			Config: exocompute,
 			Check: resource.ComposeTestCheckFunc(
 				// Subscription resource
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_id", subscription.SubscriptionID),

--- a/internal/provider/resource_azure_service_principal_test.go
+++ b/internal/provider/resource_azure_service_principal_test.go
@@ -45,8 +45,7 @@ func TestAccPolarisAzureServicePrincipal_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			PreConfig: testStepDelay,
-			Config:    servicePrincipal,
+			Config: servicePrincipal,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_azure_service_principal.default", "id", subscription.PrincipalID),
 				resource.TestCheckResourceAttr("polaris_azure_service_principal.default", "credentials", subscription.Credentials),
@@ -67,8 +66,7 @@ func TestAccPolarisAzureServicePrincipal_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			PreConfig: testStepDelay,
-			Config:    servicePrincipal,
+			Config: servicePrincipal,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_azure_service_principal.default", "id", subscription.PrincipalID),
 				resource.TestCheckResourceAttr("polaris_azure_service_principal.default", "app_id", subscription.PrincipalID),

--- a/internal/provider/resource_azure_subscription_test.go
+++ b/internal/provider/resource_azure_subscription_test.go
@@ -76,8 +76,7 @@ func TestAccPolarisAzureSubscription_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			PreConfig: testStepDelay,
-			Config:    subscriptionOneRegion,
+			Config: subscriptionOneRegion,
 			Check: resource.ComposeTestCheckFunc(
 				// Subscription resource
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_id", subscription.SubscriptionID),
@@ -91,8 +90,7 @@ func TestAccPolarisAzureSubscription_basic(t *testing.T) {
 				resource.TestCheckTypeSetElemAttr("polaris_azure_subscription.default", "cloud_native_protection.0.regions.*", "eastus2"),
 			),
 		}, {
-			PreConfig: testStepDelay,
-			Config:    subscriptionTwoRegions,
+			Config: subscriptionTwoRegions,
 			Check: resource.ComposeTestCheckFunc(
 				// Subscription resource
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_id", subscription.SubscriptionID),
@@ -107,8 +105,7 @@ func TestAccPolarisAzureSubscription_basic(t *testing.T) {
 				resource.TestCheckTypeSetElemAttr("polaris_azure_subscription.default", "cloud_native_protection.0.regions.*", "westus2"),
 			),
 		}, {
-			PreConfig: testStepDelay,
-			Config:    subscriptionOneRegion,
+			Config: subscriptionOneRegion,
 			Check: resource.ComposeTestCheckFunc(
 				// Subscription resource
 				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_id", subscription.SubscriptionID),

--- a/internal/provider/resource_gcp_project_test.go
+++ b/internal/provider/resource_gcp_project_test.go
@@ -57,8 +57,7 @@ func TestAccPolarisGCPProject_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			PreConfig: testStepDelay,
-			Config:    projectCredentials,
+			Config: projectCredentials,
 			Check: resource.ComposeTestCheckFunc(
 				// Project resource
 				resource.TestCheckResourceAttr("polaris_gcp_project.default", "credentials", project.Credentials),
@@ -82,8 +81,7 @@ func TestAccPolarisGCPProject_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			PreConfig: testStepDelay,
-			Config:    projectValues,
+			Config: projectValues,
 			Check: resource.ComposeTestCheckFunc(
 				// Project resource
 				resource.TestCheckResourceAttr("polaris_gcp_project.default", "project", project.ProjectID),

--- a/internal/provider/resource_gcp_service_account_test.go
+++ b/internal/provider/resource_gcp_service_account_test.go
@@ -35,8 +35,7 @@ func TestAccPolarisGCPServiceAccount_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{{
-			PreConfig: testStepDelay,
-			Config:    serviceAccount,
+			Config: serviceAccount,
 			Check: resource.ComposeTestCheckFunc(
 				resource.TestCheckResourceAttr("polaris_gcp_service_account.default", "id", id),
 				resource.TestCheckResourceAttr("polaris_gcp_service_account.default", "credentials", project.Credentials),


### PR DESCRIPTION
A preconfig added 10s delay between each test to avoid rate limit
issues. This change removes the delay and instead keep a single instance
of the provider during tests.
