### PR TITLE
Explicitly remove exocompute (#110)

### DIFF
--- a/internal/provider/resource_aws_account.go
+++ b/internal/provider/resource_aws_account.go
@@ -560,10 +560,18 @@ func awsDeleteAccount(ctx context.Context, d *schema.ResourceData, m interface{}
 		return diag.Errorf("resource id and profile/role refer to different accounts")
 	}
 
-	// Removing Cloud Native Protection also removes Exocompute.
-	err = aws.Wrap(client).RemoveAccount(ctx, account, []core.Feature{core.FeatureCloudNativeProtection}, deleteSnapshots)
-	if err != nil {
-		return diag.FromErr(err)
+	if _, ok := d.GetOk("exocompute"); ok {
+		err = aws.Wrap(client).RemoveAccount(ctx, account, []core.Feature{core.FeatureExocompute}, deleteSnapshots)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
+	if _, ok := d.GetOk("cloud_native_protection"); ok {
+		err = aws.Wrap(client).RemoveAccount(ctx, account, []core.Feature{core.FeatureCloudNativeProtection}, deleteSnapshots)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 	}
 
 	d.SetId("")


### PR DESCRIPTION
A backend change to RSC has decoupled the Exocompute feature from the Cloud Native Protection feature, so the Exocompute feature is no longer automatically removed when the Cloud Native Protection feature is removed.
