### PR TITLE
Fix polaris_aws_cnp_permissions id

### DIFF
--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -4,6 +4,10 @@ page_title: "Changelog"
 
 # Changelog
 
+## v0.10.0-beta.9
+* Fix a bug in the `polaris_aws_cnp_permissions` data source where the data source's id was accidentally calculated for
+  the complete set of role keys and not just the specified role key.
+
 ## v0.10.0-beta.8
 * Add the `permissions` field to the `polaris_aws_cnp_account_attachments` resource. The `permissions` field should be
   used with the `id` field of the `polaris_aws_cnp_permissions` data source to trigger an update of the resource

--- a/docs/resources/aws_cnp_account_attachments.md
+++ b/docs/resources/aws_cnp_account_attachments.md
@@ -38,8 +38,9 @@ resource "polaris_aws_cnp_account_attachments" "attachments" {
   dynamic "role" {
     for_each = aws_iam_role.role
     content {
-      key = role.key
-      arn = role.value["arn"]
+      key         = role.key
+      arn         = role.value["arn"]
+      permissions = data.polaris_aws_cnp_permissions.permissions[role.key].id
     }
   }
 }

--- a/examples/resources/polaris_aws_cnp_account_attachments/resource.tf
+++ b/examples/resources/polaris_aws_cnp_account_attachments/resource.tf
@@ -16,8 +16,9 @@ resource "polaris_aws_cnp_account_attachments" "attachments" {
   dynamic "role" {
     for_each = aws_iam_role.role
     content {
-      key = role.key
-      arn = role.value["arn"]
+      key         = role.key
+      arn         = role.value["arn"]
+      permissions = data.polaris_aws_cnp_permissions.permissions[role.key].id
     }
   }
 }

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -4,6 +4,10 @@ page_title: "Changelog"
 
 # Changelog
 
+## v0.10.0-beta.9
+* Fix a bug in the `polaris_aws_cnp_permissions` data source where the data source's id was accidentally calculated for
+  the complete set of role keys and not just the specified role key.
+
 ## v0.10.0-beta.8
 * Add the `permissions` field to the `polaris_aws_cnp_account_attachments` resource. The `permissions` field should be
   used with the `id` field of the `polaris_aws_cnp_permissions` data source to trigger an update of the resource


### PR DESCRIPTION
The data source's id was accidentally calculated for the complete set of role keys and not just the specified role key.