### PR TITLE
Fix Azure exocompute bug

### DIFF
--- a/internal/provider/resource_azure_exocompute.go
+++ b/internal/provider/resource_azure_exocompute.go
@@ -165,7 +165,7 @@ func azureCreateExocompute(ctx context.Context, d *schema.ResourceData, m interf
 		if err != nil {
 			return diag.FromErr(err)
 		}
-		err = exocompute.Wrap(client).MapAWSCloudAccount(ctx, accountID, hostCloudAccountID)
+		err = exocompute.Wrap(client).MapAzureCloudAccount(ctx, accountID, hostCloudAccountID)
 		if err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
The polaris_azure_excompute resource incorrectly called the AWS GraphQL endpoint when mapping an Azure cloud account.