### PR TITLE
Only add AWS subnets with names to the set of subnets

### DIFF
--- a/internal/provider/resource_aws_exocompute.go
+++ b/internal/provider/resource_aws_exocompute.go
@@ -274,8 +274,12 @@ func awsReadExocompute(ctx context.Context, d *schema.ResourceData, m interface{
 			return diag.FromErr(err)
 		}
 		subnets := schema.Set{F: schema.HashString}
-		subnets.Add(exoConfig.Subnet1.ID)
-		subnets.Add(exoConfig.Subnet2.ID)
+		if exoConfig.Subnet1.ID != "" {
+			subnets.Add(exoConfig.Subnet1.ID)
+		}
+		if exoConfig.Subnet2.ID != "" {
+			subnets.Add(exoConfig.Subnet2.ID)
+		}
 		if err := d.Set(keySubnets, &subnets); err != nil {
 			return diag.FromErr(err)
 		}


### PR DESCRIPTION
When using AWS BYOK no subnets are specified, RSC will return an empty string in the API response.