### PR TITLE
Fix polaris_role_assignment and polaris_user migration issues

### DIFF
--- a/internal/provider/resource_role_assignment_v0.go
+++ b/internal/provider/resource_role_assignment_v0.go
@@ -80,5 +80,5 @@ func resourceRoleAssignmentStateUpgradeV0(ctx context.Context, state map[string]
 	}
 
 	state[keyID] = user.ID
-	return nil, nil
+	return state, nil
 }

--- a/internal/provider/resource_user_v0.go
+++ b/internal/provider/resource_user_v0.go
@@ -90,5 +90,6 @@ func resourceUserStateUpgradeV0(ctx context.Context, state map[string]any, m any
 	}
 
 	state[keyID] = user.ID
-	return nil, nil
+	state[keyDomain] = user.Domain
+	return state, nil
 }


### PR DESCRIPTION
The migrated state was never returned from the function handling the migration.