### PR TITLE
fix: convert aws_account datasource returned cloud_account_id to string

### DIFF
--- a/internal/provider/data_source_aws_account.go
+++ b/internal/provider/data_source_aws_account.go
@@ -120,7 +120,7 @@ func awsAccountRead(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 	if err := d.Set(keyAccountID, account.NativeID); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set(keyCloudAccountID, account.ID); err != nil {
+	if err := d.Set(keyCloudAccountID, account.ID.String()); err != nil {
 		return diag.FromErr(err)
 	}
 	if err := d.Set(keyName, account.Name); err != nil {


### PR DESCRIPTION
Based on https://github.com/rubrikinc/terraform-provider-polaris/issues/243 ;
currently, instantiating an aws account data source fails with `cloud_account_id: '' expected type 'string', got unconvertible type 'uuid.UUID', value: '<CLOUD_ACCOUNT_UUID>'` because of mismatched types in https://github.com/rubrikinc/terraform-provider-polaris/blob/beta/internal/provider/data_source_aws_account.go#L123 . This PR fixes the error by converting the UUID to a string, as is done later on in the function as well.