### PR TITLE
Improve logging by using tflog instead of stdlib log

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,29 @@ The following environmental variables can be used to override the default behavi
 * *RUBRIK_POLARIS_TOKEN_CACHE_SECRET* — Overrides the secret used as input when generating an encryption key for the
   authentication token.
 
+### Terraform Logging Support
+The provider supports Terraform's native logging system (tflog) for improved debugging and troubleshooting. This provides structured logging with better integration into Terraform's logging infrastructure.
+
+#### Terraform Logging Environment Variables
+* *TF_LOG_PROVIDER_POLARIS* — Controls the log level for the Terraform provider itself. Valid log levels are: *TRACE*, *DEBUG*, *INFO*, *WARN*, *ERROR*, and *OFF*. This variable follows Terraform's standard logging conventions.
+* *TF_LOG_PROVIDER_POLARIS_API* — Controls the log level specifically for API calls made by the provider to the Polaris service. This allows you to separately control the verbosity of API-related logging.
+
+#### Usage Examples
+```bash
+# Enable DEBUG logging for the provider, including API calls
+export TF_LOG_PROVIDER_POLARIS=DEBUG
+
+# Enable TRACE logging for API calls only
+export TF_LOG_PROVIDER_POLARIS_API=TRACE
+
+# Enable both provider and API logging at different levels
+export TF_LOG_PROVIDER_POLARIS=INFO
+export TF_LOG_PROVIDER_POLARIS_API=DEBUG
+
+# Direct provider logs to a specific file
+export TF_LOG_PROVIDER_PATH=./polaris-provider.log
+```
+
 ### Provider Credentials
 The provider supports both local user accounts and service accounts. For documentation on how to create either using
 Polaris see the [Rubrik Support Portal](http://support.rubrik.com).

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,6 +110,29 @@ account behavior:
 * `RUBRIK_POLARIS_ACCOUNT_PASSWORD` - Overrides the password of the local user account.
 * `RUBRIK_POLARIS_ACCOUNT_URL` - Overrides the RSC API URL.
 
+### Terraform Logging Support
+The provider supports Terraform's native logging system (tflog) for improved debugging and troubleshooting. This provides structured logging with better integration into Terraform's logging infrastructure.
+
+#### Terraform Logging Environment Variables
+* `TF_LOG_PROVIDER_POLARIS` - Controls the log level for the Terraform provider itself. Valid log levels are: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, and `OFF`. This variable follows Terraform's standard logging conventions.
+* `TF_LOG_PROVIDER_POLARIS_API` - Controls the log level specifically for API calls made by the provider to the Polaris service. This allows you to separately control the verbosity of API-related logging.
+
+#### Usage Examples
+```bash
+# Enable DEBUG logging for the provider, including API calls
+export TF_LOG_PROVIDER_POLARIS=DEBUG
+
+# Enable TRACE logging for API calls only
+export TF_LOG_PROVIDER_POLARIS_API=TRACE
+
+# Enable both provider and API logging at different levels
+export TF_LOG_PROVIDER_POLARIS=INFO
+export TF_LOG_PROVIDER_POLARIS_API=DEBUG
+
+# Direct provider logs to a specific file
+export TF_LOG_PROVIDER_PATH=./polaris-provider.log
+```
+
 ## Example Usage
 
 ```terraform

--- a/internal/provider/data_source_account.go
+++ b/internal/provider/data_source_account.go
@@ -24,9 +24,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
@@ -73,7 +73,7 @@ func dataSourceAccount() *schema.Resource {
 }
 
 func accountRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] accountRead")
+	tflog.Trace(ctx, "accountRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_aws_account.go
+++ b/internal/provider/data_source_aws_account.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -84,7 +84,7 @@ func dataSourceAwsAccount() *schema.Resource {
 }
 
 func awsAccountRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] awsAccountRead")
+	tflog.Trace(ctx, "awsAccountRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_aws_archival_location.go
+++ b/internal/provider/data_source_aws_archival_location.go
@@ -22,10 +22,10 @@ package provider
 
 import (
 	"context"
-	"log"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -114,7 +114,7 @@ func dataSourceAwsArchivalLocation() *schema.Resource {
 }
 
 func awsArchivalLocationRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] awsArchivalLocationRead")
+	tflog.Trace(ctx, "awsArchivalLocationRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_aws_cnp_artifacts.go
+++ b/internal/provider/data_source_aws_cnp_artifacts.go
@@ -24,8 +24,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -111,7 +111,7 @@ func dataSourceAwsArtifacts() *schema.Resource {
 }
 
 func awsArtifactsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsArtifactsRead")
+	tflog.Trace(ctx, "awsArtifactsRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_aws_cnp_permissions.go
+++ b/internal/provider/data_source_aws_cnp_permissions.go
@@ -24,8 +24,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -139,7 +139,7 @@ func dataSourceAwsPermissions() *schema.Resource {
 }
 
 func awsPermissionsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsPermissionsRead")
+	tflog.Trace(ctx, "awsPermissionsRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_azure_archival_location.go
+++ b/internal/provider/data_source_azure_archival_location.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -129,7 +129,7 @@ func dataSourceAzureArchivalLocation() *schema.Resource {
 }
 
 func azureArchivalLocationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureArchivalLocationRead")
+	tflog.Trace(ctx, "azureArchivalLocationRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_azure_permissions.go
+++ b/internal/provider/data_source_azure_permissions.go
@@ -24,8 +24,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -295,7 +295,7 @@ func dataSourceAzurePermissions() *schema.Resource {
 }
 
 func azurePermissionsRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] azurePermissionsRead")
+	tflog.Trace(ctx, "azurePermissionsRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_azure_subscription.go
+++ b/internal/provider/data_source_azure_subscription.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -79,7 +79,7 @@ func dataSourceAzureSubscription() *schema.Resource {
 }
 
 func azureSubscriptionRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] azureSubscriptionRead")
+	tflog.Trace(ctx, "azureSubscriptionRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_data_center_aws_account.go
+++ b/internal/provider/data_source_data_center_aws_account.go
@@ -22,8 +22,8 @@ package provider
 
 import (
 	"context"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -79,7 +79,7 @@ func dataSourceDataCenterAWSAccount() *schema.Resource {
 }
 
 func dataCenterAWSAccountRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterAWSAccountRead")
+	tflog.Trace(ctx, "dataCenterAWSAccountRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_data_center_azure_subscription.go
+++ b/internal/provider/data_source_data_center_azure_subscription.go
@@ -22,8 +22,8 @@ package provider
 
 import (
 	"context"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -84,7 +84,7 @@ func dataSourceDataCenterAzureSubscription() *schema.Resource {
 }
 
 func dataCenterAzureSubscriptionRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterAzureSubscriptionRead")
+	tflog.Trace(ctx, "dataCenterAzureSubscriptionRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_deployment.go
+++ b/internal/provider/data_source_deployment.go
@@ -24,8 +24,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
@@ -65,7 +65,7 @@ func dataSourceDeployment() *schema.Resource {
 }
 
 func deploymentRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] deploymentRead")
+	tflog.Trace(ctx, "deploymentRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_features.go
+++ b/internal/provider/data_source_features.go
@@ -25,9 +25,9 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"log"
 	"slices"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
@@ -66,7 +66,7 @@ func dataSourceFeatures() *schema.Resource {
 }
 
 func featuresRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] featuresRead")
+	tflog.Trace(ctx, "featuresRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_gcp_permissions.go
+++ b/internal/provider/data_source_gcp_permissions.go
@@ -24,11 +24,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"log"
 	"sort"
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -73,7 +73,7 @@ func dataSourceGcpPermissions() *schema.Resource {
 // gcpPermissionsRead run the Read operation for the GCP permissions data
 // source. Reads the permissions required for the specified Polaris features.
 func gcpPermissionsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] gcpPermissionsRead")
+	tflog.Trace(ctx, "gcpPermissionsRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_role.go
+++ b/internal/provider/data_source_role.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -116,7 +116,7 @@ func dataSourceRole() *schema.Resource {
 }
 
 func roleRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] roleRead")
+	tflog.Trace(ctx, "roleRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_role_template.go
+++ b/internal/provider/data_source_role_template.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -111,7 +111,7 @@ func dataSourceRoleTemplate() *schema.Resource {
 }
 
 func roleTemplateRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] roleTemplateRead")
+	tflog.Trace(ctx, "roleTemplateRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_sla_domain.go
+++ b/internal/provider/data_source_sla_domain.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -75,7 +75,7 @@ func dataSourceSLADomain() *schema.Resource {
 }
 
 func slaDomainRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] slaDomainRead")
+	tflog.Trace(ctx, "slaDomainRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_sso_group.go
+++ b/internal/provider/data_source_sso_group.go
@@ -22,8 +22,8 @@ package provider
 
 import (
 	"context"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -86,7 +86,7 @@ func dataSourceSSOGroup() *schema.Resource {
 }
 
 func ssoGroupRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] ssoGroupRead")
+	tflog.Trace(ctx, "ssoGroupRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_tag_rule.go
+++ b/internal/provider/data_source_tag_rule.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -96,7 +96,7 @@ func dataSourceTagRule() *schema.Resource {
 }
 
 func tagRuleRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] tagRuleRead")
+	tflog.Trace(ctx, "tagRuleRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/data_source_user.go
+++ b/internal/provider/data_source_user.go
@@ -22,8 +22,8 @@ package provider
 
 import (
 	"context"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -100,7 +100,7 @@ func dataSourceUser() *schema.Resource {
 }
 
 func userRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] userRead")
+	tflog.Trace(ctx, "userRead")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/logging.go
+++ b/internal/provider/logging.go
@@ -1,0 +1,86 @@
+// Copyright 2025 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/log"
+)
+
+// subSystem is the subsystem name used by the API logger.
+const subSystem = "api"
+
+type apiLogger struct {
+	// tflog embedds the logger in a context that must be passed to each log call.
+	ctx context.Context
+}
+
+var _ = log.Logger(&apiLogger{})
+
+// newAPILogger returns a new logger that logs to the Terraform log system.
+// The log level is read from the TF_LOG_PROVIDER_POLARIS_API environment.
+func newAPILogger(ctx context.Context) *apiLogger {
+	return &apiLogger{
+		ctx: tflog.NewSubsystem(ctx, subSystem, tflog.WithLevelFromEnv("TF_LOG_PROVIDER_POLARIS_API")),
+	}
+}
+
+func (l *apiLogger) Print(lvl log.LogLevel, args ...any) {
+	l.print(lvl, fmt.Sprint(args...))
+}
+
+func (l *apiLogger) Printf(lvl log.LogLevel, format string, args ...any) {
+	l.print(lvl, fmt.Sprintf(format, args...))
+}
+
+func (l *apiLogger) print(level log.LogLevel, msg string) {
+	var fields map[string]any
+
+	// Extract caller similar to how rubrik-polaris-sdk-for-go/pkg/polaris/log does it.
+	if n := log.PkgFuncName(3); n != "" {
+		fields = map[string]any{"call": n}
+	}
+
+	switch level {
+	case log.Trace:
+		tflog.SubsystemTrace(l.ctx, subSystem, msg, fields)
+	case log.Debug:
+		tflog.SubsystemDebug(l.ctx, subSystem, msg, fields)
+	case log.Info:
+		tflog.SubsystemInfo(l.ctx, subSystem, msg, fields)
+	case log.Warn:
+		tflog.SubsystemWarn(l.ctx, subSystem, msg, fields)
+	case log.Error:
+		tflog.SubsystemError(l.ctx, subSystem, msg, fields)
+	case log.Fatal:
+		tflog.SubsystemError(l.ctx, subSystem, msg, fields)
+		os.Exit(1)
+	}
+}
+
+func (l *apiLogger) SetLogLevel(level log.LogLevel) {
+	// We don't need to change log levels dynamically.
+	panic("not implemented")
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -154,16 +154,11 @@ type client struct {
 }
 
 func newClient(ctx context.Context, credentials string, cacheParams polaris.CacheParams) (*client, error) {
-	logger := log.NewStandardLogger()
-	if err := polaris.SetLogLevelFromEnv(logger); err != nil {
-		return nil, err
-	}
-
+	logger := newAPILogger(ctx)
 	account, err := polaris.FindAccount(credentials, true)
 	if err != nil && !errors.Is(err, polaris.ErrAccountNotFound) {
 		return nil, err
 	}
-
 	var polarisClient *polaris.Client
 	var accountErr error
 	flags := make(map[string]bool)

--- a/internal/provider/resource_aws_account.go
+++ b/internal/provider/resource_aws_account.go
@@ -23,9 +23,9 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -206,7 +206,7 @@ func resourceAwsAccount() *schema.Resource {
 }
 
 func awsCreateAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsCreateAccount")
+	tflog.Trace(ctx, "awsCreateAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -286,7 +286,7 @@ func awsCreateAccount(ctx context.Context, d *schema.ResourceData, m interface{}
 }
 
 func awsReadAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsReadAccount")
+	tflog.Trace(ctx, "awsReadAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -387,7 +387,7 @@ func awsReadAccount(ctx context.Context, d *schema.ResourceData, m interface{}) 
 }
 
 func awsUpdateAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsUpdateAccount")
+	tflog.Trace(ctx, "awsUpdateAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -525,7 +525,7 @@ func awsUpdateAccount(ctx context.Context, d *schema.ResourceData, m interface{}
 }
 
 func awsDeleteAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsDeleteAccount")
+	tflog.Trace(ctx, "awsDeleteAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_aws_account_v0.go
+++ b/internal/provider/resource_aws_account_v0.go
@@ -23,11 +23,11 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 	"strings"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -74,7 +74,7 @@ func resourceAwsAccountV0() *schema.Resource {
 // resourceAwsAccountStateUpgradeV0 simplifies the resource id to consist of
 // only the Polaris cloud account id.
 func resourceAwsAccountStateUpgradeV0(ctx context.Context, state map[string]interface{}, m interface{}) (map[string]interface{}, error) {
-	log.Print("[TRACE] resourceAwsAccountStateUpgradeV0")
+	tflog.Trace(ctx, "resourceAwsAccountStateUpgradeV0")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_aws_account_v1.go
+++ b/internal/provider/resource_aws_account_v1.go
@@ -23,9 +23,9 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/aws"
@@ -91,7 +91,7 @@ func resourceAwsAccountV1() *schema.Resource {
 // resourceAwsAccountStateUpgradeV1 introduces a cloud native protection
 // feature block and adds status to both feature blocks.
 func resourceAwsAccountStateUpgradeV1(ctx context.Context, state map[string]interface{}, m interface{}) (map[string]interface{}, error) {
-	log.Print("[TRACE] resourceAwsAccountStateUpgradeV1")
+	tflog.Trace(ctx, "resourceAwsAccountStateUpgradeV1")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_aws_archival_location.go
+++ b/internal/provider/resource_aws_archival_location.go
@@ -23,10 +23,10 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -144,7 +144,7 @@ func resourceAwsArchivalLocation() *schema.Resource {
 }
 
 func awsCreateArchivalLocation(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsCreateArchivalLocation")
+	tflog.Trace(ctx, "awsCreateArchivalLocation")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -176,7 +176,7 @@ func awsCreateArchivalLocation(ctx context.Context, d *schema.ResourceData, m in
 }
 
 func awsReadArchivalLocation(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsReadArchivalLocation")
+	tflog.Trace(ctx, "awsReadArchivalLocation")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -229,7 +229,7 @@ func awsReadArchivalLocation(ctx context.Context, d *schema.ResourceData, m inte
 }
 
 func awsUpdateArchivalLocation(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsUpdateArchivalLocation")
+	tflog.Trace(ctx, "awsUpdateArchivalLocation")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -260,7 +260,7 @@ func awsUpdateArchivalLocation(ctx context.Context, d *schema.ResourceData, m in
 }
 
 func awsDeleteArchivalLocation(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsDeleteArchivalLocation")
+	tflog.Trace(ctx, "awsDeleteArchivalLocation")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_aws_cnp_account.go
+++ b/internal/provider/resource_aws_cnp_account.go
@@ -23,9 +23,9 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -139,7 +139,7 @@ func resourceAwsCnpAccount() *schema.Resource {
 }
 
 func awsCreateCnpAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsCreateCnpAccount")
+	tflog.Trace(ctx, "awsCreateCnpAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -180,7 +180,7 @@ func awsCreateCnpAccount(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func awsReadCnpAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsReadCnpAccount")
+	tflog.Trace(ctx, "awsReadCnpAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -241,7 +241,7 @@ func awsReadCnpAccount(ctx context.Context, d *schema.ResourceData, m interface{
 }
 
 func awsUpdateCnpAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsUpdateCnpAccount")
+	tflog.Trace(ctx, "awsUpdateCnpAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -345,7 +345,7 @@ func awsUpdateCnpAccount(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func awsDeleteCnpAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsDeleteCnpAccount")
+	tflog.Trace(ctx, "awsDeleteCnpAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_aws_cnp_account_attachments.go
+++ b/internal/provider/resource_aws_cnp_account_attachments.go
@@ -23,9 +23,9 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -94,7 +94,7 @@ func resourceAwsCnpAccountAttachments() *schema.Resource {
 }
 
 func awsCreateCnpAccountAttachments(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsCreateCnpAccountAttachments")
+	tflog.Trace(ctx, "awsCreateCnpAccountAttachments")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -132,7 +132,7 @@ func awsCreateCnpAccountAttachments(ctx context.Context, d *schema.ResourceData,
 }
 
 func awsReadCnpAccountAttachments(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsReadCnpAccountAttachments")
+	tflog.Trace(ctx, "awsReadCnpAccountAttachments")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -193,7 +193,7 @@ func awsReadCnpAccountAttachments(ctx context.Context, d *schema.ResourceData, m
 }
 
 func awsUpdateCnpAccountAttachments(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsUpdateCnpAccountAttachments")
+	tflog.Trace(ctx, "awsUpdateCnpAccountAttachments")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -238,7 +238,7 @@ func awsUpdateCnpAccountAttachments(ctx context.Context, d *schema.ResourceData,
 }
 
 func awsDeleteCnpAccountAttachments(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsDeleteCnpAccountAttachments")
+	tflog.Trace(ctx, "awsDeleteCnpAccountAttachments")
 
 	// Reset ID.
 	d.SetId("")

--- a/internal/provider/resource_aws_cnp_account_trust_policy.go
+++ b/internal/provider/resource_aws_cnp_account_trust_policy.go
@@ -24,9 +24,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -104,7 +104,7 @@ func resourceAwsCnpAccountTrustPolicy() *schema.Resource {
 }
 
 func awsCreateCnpAccountTrustPolicy(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsCreateCnpAccountTrustPolicy")
+	tflog.Trace(ctx, "awsCreateCnpAccountTrustPolicy")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -137,7 +137,7 @@ func awsCreateCnpAccountTrustPolicy(ctx context.Context, d *schema.ResourceData,
 }
 
 func awsReadCnpAccountTrustPolicy(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsReadCnpAccountTrustPolicy")
+	tflog.Trace(ctx, "awsReadCnpAccountTrustPolicy")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -187,7 +187,7 @@ func awsReadCnpAccountTrustPolicy(ctx context.Context, d *schema.ResourceData, m
 }
 
 func awsUpdateCnpAccountTrustPolicy(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsUpdateCnpAccountTrustPolicy")
+	tflog.Trace(ctx, "awsUpdateCnpAccountTrustPolicy")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -224,7 +224,7 @@ func awsUpdateCnpAccountTrustPolicy(ctx context.Context, d *schema.ResourceData,
 // there is no need to destroy the trust policy in RSC, we simply remove the
 // trust policy from the state.
 func awsDeleteCnpAccountTrustPolicy(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsDeleteCnpAccountTrustPolicy")
+	tflog.Trace(ctx, "awsDeleteCnpAccountTrustPolicy")
 
 	// Reset ID.
 	d.SetId("")

--- a/internal/provider/resource_aws_custom_tags.go
+++ b/internal/provider/resource_aws_custom_tags.go
@@ -22,8 +22,8 @@ package provider
 
 import (
 	"context"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
@@ -87,7 +87,7 @@ func resourceAwsCustomTags() *schema.Resource {
 }
 
 func awsCreateCustomTags(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsCreateCustomTags")
+	tflog.Trace(ctx, "awsCreateCustomTags")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -112,7 +112,7 @@ func awsCreateCustomTags(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func awsReadCustomTags(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsReadCustomTags")
+	tflog.Trace(ctx, "awsReadCustomTags")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -134,7 +134,7 @@ func awsReadCustomTags(ctx context.Context, d *schema.ResourceData, m interface{
 }
 
 func awsUpdateCustomTags(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsUpdateCustomTags")
+	tflog.Trace(ctx, "awsUpdateCustomTags")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -170,7 +170,7 @@ func awsUpdateCustomTags(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func awsDeleteCustomTags(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsDeleteCustomTags")
+	tflog.Trace(ctx, "awsDeleteCustomTags")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_aws_exocompute.go
+++ b/internal/provider/resource_aws_exocompute.go
@@ -23,10 +23,10 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -162,7 +162,7 @@ func resourceAwsExocompute() *schema.Resource {
 }
 
 func awsCreateExocompute(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsCreateExocompute")
+	tflog.Trace(ctx, "awsCreateExocompute")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -220,7 +220,7 @@ func awsCreateExocompute(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func awsReadExocompute(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsReadExocompute")
+	tflog.Trace(ctx, "awsReadExocompute")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -292,7 +292,7 @@ func awsReadExocompute(ctx context.Context, d *schema.ResourceData, m interface{
 }
 
 func awsDeleteExocompute(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsDeleteExocompute")
+	tflog.Trace(ctx, "awsDeleteExocompute")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_aws_exocompute_cluster_attachment.go
+++ b/internal/provider/resource_aws_exocompute_cluster_attachment.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -103,7 +103,7 @@ func resourceAwsExocomputeClusterAttachment() *schema.Resource {
 }
 
 func awsCreateAwsExocomputeClusterAttachment(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsCreateAwsExocomputeClusterAttachment")
+	tflog.Trace(ctx, "awsCreateAwsExocomputeClusterAttachment")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -142,7 +142,7 @@ func awsCreateAwsExocomputeClusterAttachment(ctx context.Context, d *schema.Reso
 }
 
 func awsReadAwsExocomputeClusterAttachment(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsReadAwsExocomputeClusterAttachment")
+	tflog.Trace(ctx, "awsReadAwsExocomputeClusterAttachment")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -157,7 +157,7 @@ func awsReadAwsExocomputeClusterAttachment(ctx context.Context, d *schema.Resour
 
 	info, err := exocompute.Wrap(client).AWSClusterConnection(ctx, clusterName, configID)
 	if err != nil {
-		log.Printf("[INFO] failed to read cluster attachment: %s", err)
+		tflog.Warn(ctx, "failed to read cluster attachment", map[string]any{"err": err.Error()})
 		return nil
 	}
 	if err := d.Set(keyConnectionCommand, info.Command); err != nil {
@@ -177,7 +177,7 @@ func awsReadAwsExocomputeClusterAttachment(ctx context.Context, d *schema.Resour
 }
 
 func awsUpdateAwsExocomputeClusterAttachment(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsUpdateAwsExocomputeClusterAttachment")
+	tflog.Trace(ctx, "awsUpdateAwsExocomputeClusterAttachment")
 
 	if d.HasChange(keyTokenRefresh) {
 		return awsCreateAwsExocomputeClusterAttachment(ctx, d, m)
@@ -187,7 +187,7 @@ func awsUpdateAwsExocomputeClusterAttachment(ctx context.Context, d *schema.Reso
 }
 
 func awsDeleteAwsExocomputeClusterAttachment(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsDeleteAwsExocomputeClusterAttachment")
+	tflog.Trace(ctx, "awsDeleteAwsExocomputeClusterAttachment")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_aws_private_container_registry.go
+++ b/internal/provider/resource_aws_private_container_registry.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -136,7 +136,7 @@ func resourceAwsPrivateContainerRegistry() *schema.Resource {
 }
 
 func awsCreatePrivateContainerRegistry(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsCreatePrivateContainerRegistry")
+	tflog.Trace(ctx, "awsCreatePrivateContainerRegistry")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -159,7 +159,7 @@ func awsCreatePrivateContainerRegistry(ctx context.Context, d *schema.ResourceDa
 }
 
 func awsReadPrivateContainerRegistry(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsReadPrivateContainerRegistry")
+	tflog.Trace(ctx, "awsReadPrivateContainerRegistry")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -186,7 +186,7 @@ func awsReadPrivateContainerRegistry(ctx context.Context, d *schema.ResourceData
 }
 
 func awsUpdatePrivateContainerRegistry(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsUpdatePrivateContainerRegistry")
+	tflog.Trace(ctx, "awsUpdatePrivateContainerRegistry")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -207,7 +207,7 @@ func awsUpdatePrivateContainerRegistry(ctx context.Context, d *schema.ResourceDa
 }
 
 func awsDeletePrivateContainerRegistry(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] awsDeletePrivateContainerRegistry")
+	tflog.Trace(ctx, "awsDeletePrivateContainerRegistry")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_azure_archival_location.go
+++ b/internal/provider/resource_azure_archival_location.go
@@ -23,10 +23,10 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 	"regexp"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -157,7 +157,7 @@ func resourceAzureArchivalLocation() *schema.Resource {
 }
 
 func azureCreateArchivalLocation(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureCreateArchivalLocation")
+	tflog.Trace(ctx, "azureCreateArchivalLocation")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -195,7 +195,7 @@ func azureCreateArchivalLocation(ctx context.Context, d *schema.ResourceData, m 
 }
 
 func azureReadArchivalLocation(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureReadArchivalLocation")
+	tflog.Trace(ctx, "azureReadArchivalLocation")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -255,7 +255,7 @@ func azureReadArchivalLocation(ctx context.Context, d *schema.ResourceData, m in
 }
 
 func azureUpdateArchivalLocation(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureUpdateArchivalLocation")
+	tflog.Trace(ctx, "azureUpdateArchivalLocation")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -283,7 +283,7 @@ func azureUpdateArchivalLocation(ctx context.Context, d *schema.ResourceData, m 
 }
 
 func azureDeleteArchivalLocation(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureDeleteArchivalLocation")
+	tflog.Trace(ctx, "azureDeleteArchivalLocation")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_azure_custom_tags.go
+++ b/internal/provider/resource_azure_custom_tags.go
@@ -22,8 +22,8 @@ package provider
 
 import (
 	"context"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
@@ -87,7 +87,7 @@ func resourceAzureCustomTags() *schema.Resource {
 }
 
 func azureCreateCustomTags(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureCreateCustomTags")
+	tflog.Trace(ctx, "azureCreateCustomTags")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -112,7 +112,7 @@ func azureCreateCustomTags(ctx context.Context, d *schema.ResourceData, m interf
 }
 
 func azureReadCustomTags(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureReadCustomTags")
+	tflog.Trace(ctx, "azureReadCustomTags")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -134,7 +134,7 @@ func azureReadCustomTags(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func azureUpdateCustomTags(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureUpdateCustomTags")
+	tflog.Trace(ctx, "azureUpdateCustomTags")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -170,7 +170,7 @@ func azureUpdateCustomTags(ctx context.Context, d *schema.ResourceData, m interf
 }
 
 func azureDeleteCustomTags(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureDeleteCustomTags")
+	tflog.Trace(ctx, "azureDeleteCustomTags")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_azure_exocompute.go
+++ b/internal/provider/resource_azure_exocompute.go
@@ -23,10 +23,10 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -144,7 +144,7 @@ func resourceAzureExocompute() *schema.Resource {
 }
 
 func azureCreateExocompute(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureCreateExocompute")
+	tflog.Trace(ctx, "azureCreateExocompute")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -193,7 +193,7 @@ func azureCreateExocompute(ctx context.Context, d *schema.ResourceData, m interf
 }
 
 func azureReadExocompute(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureReadExocompute")
+	tflog.Trace(ctx, "azureReadExocompute")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -248,7 +248,7 @@ func azureReadExocompute(ctx context.Context, d *schema.ResourceData, m interfac
 }
 
 func azureDeleteExocompute(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureDeleteExocompute")
+	tflog.Trace(ctx, "azureDeleteExocompute")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_azure_exocompute_cluster_attachment.go
+++ b/internal/provider/resource_azure_exocompute_cluster_attachment.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -87,7 +87,7 @@ func resourceAzureExocomputeClusterAttachment() *schema.Resource {
 }
 
 func azureCreateAwsExocomputeClusterAttachment(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureCreateAwsExocomputeClusterAttachment")
+	tflog.Trace(ctx, "azureCreateAwsExocomputeClusterAttachment")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -113,7 +113,7 @@ func azureCreateAwsExocomputeClusterAttachment(ctx context.Context, d *schema.Re
 }
 
 func azureReadAwsExocomputeClusterAttachment(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureReadAwsExocomputeClusterAttachment")
+	tflog.Trace(ctx, "azureReadAwsExocomputeClusterAttachment")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -128,7 +128,7 @@ func azureReadAwsExocomputeClusterAttachment(ctx context.Context, d *schema.Reso
 
 	info, err := exocompute.Wrap(client).AzureClusterConnection(ctx, clusterName, configID)
 	if err != nil {
-		log.Printf("[INFO] failed to read cluster attachment: %s", err)
+		tflog.Warn(ctx, "failed to read cluster attachment", map[string]any{"err": err.Error()})
 		return nil
 	}
 	if err := d.Set(keyManifest, info.Manifest); err != nil {
@@ -139,7 +139,7 @@ func azureReadAwsExocomputeClusterAttachment(ctx context.Context, d *schema.Reso
 }
 
 func azureUpdateAwsExocomputeClusterAttachment(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureUpdateAwsExocomputeClusterAttachment")
+	tflog.Trace(ctx, "azureUpdateAwsExocomputeClusterAttachment")
 
 	if d.HasChange(keyTokenRefresh) {
 		return awsCreateAwsExocomputeClusterAttachment(ctx, d, m)
@@ -149,7 +149,7 @@ func azureUpdateAwsExocomputeClusterAttachment(ctx context.Context, d *schema.Re
 }
 
 func azureDeleteAwsExocomputeClusterAttachment(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureDeleteAwsExocomputeClusterAttachment")
+	tflog.Trace(ctx, "azureDeleteAwsExocomputeClusterAttachment")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_azure_exocompute_v0.go
+++ b/internal/provider/resource_azure_exocompute_v0.go
@@ -22,8 +22,8 @@ package provider
 
 import (
 	"context"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -67,7 +67,7 @@ func resourceAzureExocomputeV0() *schema.Resource {
 // resourceAzureExocomputeStateUpgradeV0 removes the polaris_managed parameter.
 // Exocompute on Azure only supports RSC managed configurations.
 func resourceAzureExocomputeStateUpgradeV0(ctx context.Context, state map[string]any, m any) (map[string]any, error) {
-	log.Print("[TRACE] azureExocomputeStateUpgradeV0")
+	tflog.Trace(ctx, "azureExocomputeStateUpgradeV0")
 
 	delete(state, "polaris_managed")
 

--- a/internal/provider/resource_azure_private_container_registry.go
+++ b/internal/provider/resource_azure_private_container_registry.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -122,7 +122,7 @@ func resourceAzurePrivateContainerRegistry() *schema.Resource {
 }
 
 func azureCreatePrivateContainerRegistry(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureCreatePrivateContainerRegistry")
+	tflog.Trace(ctx, "azureCreatePrivateContainerRegistry")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -148,7 +148,7 @@ func azureCreatePrivateContainerRegistry(ctx context.Context, d *schema.Resource
 }
 
 func azureReadPrivateContainerRegistry(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureReadPrivateContainerRegistry")
+	tflog.Trace(ctx, "azureReadPrivateContainerRegistry")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -175,7 +175,7 @@ func azureReadPrivateContainerRegistry(ctx context.Context, d *schema.ResourceDa
 }
 
 func azureUpdatePrivateContainerRegistry(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureUpdatePrivateContainerRegistry")
+	tflog.Trace(ctx, "azureUpdatePrivateContainerRegistry")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -199,7 +199,7 @@ func azureUpdatePrivateContainerRegistry(ctx context.Context, d *schema.Resource
 }
 
 func azureDeletePrivateContainerRegistry(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureDeletePrivateContainerRegistry")
+	tflog.Trace(ctx, "azureDeletePrivateContainerRegistry")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_azure_service_principal.go
+++ b/internal/provider/resource_azure_service_principal.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -172,7 +172,7 @@ func resourceAzureServicePrincipal() *schema.Resource {
 // principal resource. This adds the Azure service principal to the RSC
 // platform.
 func azureCreateServicePrincipal(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureCreateServicePrincipal")
+	tflog.Trace(ctx, "azureCreateServicePrincipal")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -213,7 +213,7 @@ func azureCreateServicePrincipal(ctx context.Context, d *schema.ResourceData, m 
 // principal resource. This reads the state of the Azure service principal in
 // RSC.
 func azureReadServicePrincipal(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureReadServicePrincipal")
+	tflog.Trace(ctx, "azureReadServicePrincipal")
 
 	return nil
 }
@@ -221,7 +221,7 @@ func azureReadServicePrincipal(ctx context.Context, d *schema.ResourceData, m in
 // azureUpdateServiceAccount run the Update operation for the Azure service
 // principal resource. This updates the Azure service principal in RSC.
 func azureUpdateServicePrincipal(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureUpdateServicePrincipal")
+	tflog.Trace(ctx, "azureUpdateServicePrincipal")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -259,7 +259,7 @@ func azureUpdateServicePrincipal(ctx context.Context, d *schema.ResourceData, m 
 // principal resource. This only removes the local state of the GCP service
 // account since the service account cannot be removed using the RSC API.
 func azureDeleteServicePrincipal(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] azureDeleteServicePrincipal")
+	tflog.Trace(ctx, "azureDeleteServicePrincipal")
 
 	d.SetId("")
 	return nil

--- a/internal/provider/resource_azure_service_principal_v0.go
+++ b/internal/provider/resource_azure_service_principal_v0.go
@@ -24,9 +24,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
 	"os"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -92,7 +92,7 @@ func resourceAzureServicePrincipalV0() *schema.Resource {
 // resourceAzureServicePrincipalStateUpgradeV0 makes the tenant domain
 // parameter required.
 func resourceAzureServicePrincipalStateUpgradeV0(ctx context.Context, state map[string]interface{}, m interface{}) (map[string]interface{}, error) {
-	log.Print("[TRACE] azureServicePrincipalStateUpgradeV0")
+	tflog.Trace(ctx, "azureServicePrincipalStateUpgradeV0")
 
 	// Tenant domain is only missing when the principal has been given as a
 	// credential file.

--- a/internal/provider/resource_azure_subscription.go
+++ b/internal/provider/resource_azure_subscription.go
@@ -24,11 +24,11 @@ import (
 	"cmp"
 	"context"
 	"errors"
-	"log"
 	"maps"
 	"slices"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -748,7 +748,7 @@ func resourceAzureSubscription() *schema.Resource {
 // azureCreateSubscription run the Create operation for the Azure subscription
 // resource. This adds the Azure subscription to the RSC platform.
 func azureCreateSubscription(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] azureCreateSubscription")
+	tflog.Trace(ctx, "azureCreateSubscription")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -792,7 +792,7 @@ func azureCreateSubscription(ctx context.Context, d *schema.ResourceData, m any)
 // azureReadSubscription run the Read operation for the Azure subscription
 // resource. This reads the remote state of the Azure subscription in RSC.
 func azureReadSubscription(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] azureReadSubscription")
+	tflog.Trace(ctx, "azureReadSubscription")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -840,7 +840,7 @@ func azureReadSubscription(ctx context.Context, d *schema.ResourceData, m any) d
 // azureUpdateSubscription run the Update operation for the Azure subscription
 // resource. This updates the Azure subscription in RSC.
 func azureUpdateSubscription(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] azureUpdateSubscription")
+	tflog.Trace(ctx, "azureUpdateSubscription")
 
 	client := m.(*client)
 	polarisClient, err := client.polaris()
@@ -995,7 +995,7 @@ func azureUpdateSubscription(ctx context.Context, d *schema.ResourceData, m any)
 // azureDeleteSubscription run the Delete operation for the Azure subscription
 // resource. This removes the Azure subscription from RSC.
 func azureDeleteSubscription(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] azureDeleteSubscription")
+	tflog.Trace(ctx, "azureDeleteSubscription")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -1435,7 +1435,7 @@ func upgradeSQLDBFeatureToUseResourceGroup(ctx context.Context, client *client, 
 	// Check if the SQL DB Copy Backup feature flag is enabled for the account.
 	// We only need to upgrade accounts which has the feature flag enabled.
 	if !client.flags["CNP_AZURE_SQL_DB_COPY_BACKUP"] {
-		log.Print("[DEBUG] skipping Azure SQL DB Protection feature upgrade: feature flag CNP_AZURE_SQL_DB_COPY_BACKUP is not enabled")
+		tflog.Debug(ctx, "skipping Azure SQL DB Protection feature upgrade: feature flag CNP_AZURE_SQL_DB_COPY_BACKUP is not enabled")
 		return false, nil
 	}
 
@@ -1451,7 +1451,7 @@ func upgradeSQLDBFeatureToUseResourceGroup(ctx context.Context, client *client, 
 		return false, nil
 	}
 	if feature.ResourceGroup.Name != "" || feature.ResourceGroup.Region != "" {
-		log.Print("[DEBUG] skipping Azure SQL DB Protection feature upgrade: feature already upgraded")
+		tflog.Debug(ctx, "skipping Azure SQL DB Protection feature upgrade: feature already upgraded")
 		return false, nil
 	}
 
@@ -1463,7 +1463,9 @@ func upgradeSQLDBFeatureToUseResourceGroup(ctx context.Context, client *client, 
 	}
 
 	// Upgrade the Azure SQL DB feature to use a resource group.
-	log.Printf("[INFO] upgrading Azure SQL DB Protection feature to use resource group %q", rg.Name)
+	tflog.Info(ctx, "upgrading Azure SQL DB Protection feature to use resource group", map[string]any{
+		"resource_group": rg.Name,
+	})
 	if err := gqlazure.Wrap(polarisClient.GQL).UpgradeCloudAccountPermissionsWithoutOAuth(ctx, cloudAccountID, feature.Feature, rg); err != nil {
 		return false, err
 	}

--- a/internal/provider/resource_azure_subscription_v0.go
+++ b/internal/provider/resource_azure_subscription_v0.go
@@ -22,10 +22,10 @@ package provider
 
 import (
 	"context"
-	"log"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -79,7 +79,7 @@ func resourceAzureSubscriptionV0() *schema.Resource {
 // resourceAzureSubscriptionStateUpgradeV0 migrates the resource id from the
 // Azure subscription id to the Polaris cloud account id.
 func resourceAzureSubscriptionStateUpgradeV0(ctx context.Context, state map[string]interface{}, m interface{}) (map[string]interface{}, error) {
-	log.Print("[TRACE] azureSubscriptionStateUpgradeV0")
+	tflog.Trace(ctx, "azureSubscriptionStateUpgradeV0")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_azure_subscription_v1.go
+++ b/internal/provider/resource_azure_subscription_v1.go
@@ -23,9 +23,9 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/azure"
@@ -79,7 +79,7 @@ func resourceAzureSubscriptionV1() *schema.Resource {
 // resourceAzureSubscriptionStateUpgradeV1 introduces a cloud native protection
 // feature block.
 func resourceAzureSubscriptionStateUpgradeV1(ctx context.Context, state map[string]interface{}, m interface{}) (map[string]interface{}, error) {
-	log.Print("[TRACE] azureSubscriptionStateUpgradeV1")
+	tflog.Trace(ctx, "azureSubscriptionStateUpgradeV1")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_cdm_bootstrap.go
+++ b/internal/provider/resource_cdm_bootstrap.go
@@ -23,10 +23,10 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
 	"strconv"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -220,7 +220,7 @@ func resourceCDMBootstrap() *schema.Resource {
 }
 
 func resourceCDMBootstrapCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMBootstrapCreate")
+	tflog.Trace(ctx, "resourceCDMBootstrapCreate")
 
 	timeout, err := toBackwardsCompatibleTimeout(d)
 	if err != nil {
@@ -255,7 +255,7 @@ func resourceCDMBootstrapCreate(ctx context.Context, d *schema.ResourceData, m a
 }
 
 func resourceCDMBootstrapRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMBootstrapRead")
+	tflog.Trace(ctx, "resourceCDMBootstrapRead")
 
 	timeout, err := toBackwardsCompatibleTimeout(d)
 	if err != nil {
@@ -286,14 +286,14 @@ func resourceCDMBootstrapRead(ctx context.Context, d *schema.ResourceData, m any
 // Once a Cluster has been bootstrapped it can not be updated through the
 // bootstrap resource
 func resourceCDMBootstrapUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMBootstrapUpdate")
+	tflog.Trace(ctx, "resourceCDMBootstrapUpdate")
 	return resourceCDMBootstrapRead(ctx, d, m)
 }
 
 // Once a Cluster has been bootstrapped it cannot be un-bootstrapped, delete
 // simply removes the resource from the local state.
 func resourceCDMBootstrapDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMBootstrapDelete")
+	tflog.Trace(ctx, "resourceCDMBootstrapDelete")
 	d.SetId("")
 	return nil
 }

--- a/internal/provider/resource_cdm_bootstrap_cces_aws.go
+++ b/internal/provider/resource_cdm_bootstrap_cces_aws.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -229,7 +229,7 @@ func resourceCDMBootstrapCCESAWS() *schema.Resource {
 }
 
 func resourceCDMBootstrapCCESAWSCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMBootstrapCCESAWSCreate")
+	tflog.Trace(ctx, "resourceCDMBootstrapCCESAWSCreate")
 
 	timeout, err := toBackwardsCompatibleTimeout(d)
 	if err != nil {
@@ -265,7 +265,7 @@ func resourceCDMBootstrapCCESAWSCreate(ctx context.Context, d *schema.ResourceDa
 }
 
 func resourceCDMBootstrapCCESAWSRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMBootstrapCCESAWSRead")
+	tflog.Trace(ctx, "resourceCDMBootstrapCCESAWSRead")
 
 	timeout, err := toBackwardsCompatibleTimeout(d)
 	if err != nil {
@@ -296,14 +296,14 @@ func resourceCDMBootstrapCCESAWSRead(ctx context.Context, d *schema.ResourceData
 // Once a Cluster has been bootstrapped it can not be updated through the
 // bootstrap resource
 func resourceCDMBootstrapCCESAWSUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMBootstrapCCESAWSUpdate")
+	tflog.Trace(ctx, "resourceCDMBootstrapCCESAWSUpdate")
 	return resourceCDMBootstrapCCESAWSRead(ctx, d, m)
 }
 
 // Once a Cluster has been bootstrapped it cannot be un-bootstrapped, delete
 // simply removes the resource from the local state.
 func resourceCDMBootstrapCCESAWSDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMBootstrapCCESAWSDelete")
+	tflog.Trace(ctx, "resourceCDMBootstrapCCESAWSDelete")
 	d.SetId("")
 	return nil
 }

--- a/internal/provider/resource_cdm_bootstrap_cces_azure.go
+++ b/internal/provider/resource_cdm_bootstrap_cces_azure.go
@@ -22,9 +22,9 @@ package provider
 
 import (
 	"context"
-	"log"
 	"time"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -235,7 +235,7 @@ func resourceCDMBootstrapCCESAzure() *schema.Resource {
 }
 
 func resourceCDMBootstrapCCESAzureCreate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMBootstrapCCESAzureCreate")
+	tflog.Trace(ctx, "resourceCDMBootstrapCCESAzureCreate")
 
 	timeout, err := toBackwardsCompatibleTimeout(d)
 	if err != nil {
@@ -272,7 +272,7 @@ func resourceCDMBootstrapCCESAzureCreate(ctx context.Context, d *schema.Resource
 }
 
 func resourceCDMBootstrapCCESAzureRead(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMBootstrapCCESAzureRead")
+	tflog.Trace(ctx, "resourceCDMBootstrapCCESAzureRead")
 
 	timeout, err := toBackwardsCompatibleTimeout(d)
 	if err != nil {
@@ -303,14 +303,14 @@ func resourceCDMBootstrapCCESAzureRead(ctx context.Context, d *schema.ResourceDa
 // Once a Cluster has been bootstrapped it can not be updated through the
 // bootstrap resource
 func resourceCDMBootstrapCCESAzureUpdate(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMBootstrapCCESAzureUpdate")
+	tflog.Trace(ctx, "resourceCDMBootstrapCCESAzureUpdate")
 	return resourceCDMBootstrapCCESAzureRead(ctx, d, m)
 }
 
 // Once a Cluster has been bootstrapped it cannot be un-bootstrapped, delete
 // simply removes the resource from the local state.
 func resourceCDMBootstrapCCESAzureDelete(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMBootstrapCCESAzureDelete")
+	tflog.Trace(ctx, "resourceCDMBootstrapCCESAzureDelete")
 	d.SetId("")
 	return nil
 }

--- a/internal/provider/resource_cdm_registration.go
+++ b/internal/provider/resource_cdm_registration.go
@@ -22,8 +22,8 @@ package provider
 
 import (
 	"context"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -85,7 +85,7 @@ func resourceCDMRegistration() *schema.Resource {
 }
 
 func resourceCDMRegistrationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMRegistrationCreate")
+	tflog.Trace(ctx, "resourceCDMRegistrationCreate")
 
 	adminPassword := d.Get(keyAdminPassword).(string)
 	nodeIP := d.Get(keyClusterNodeIPAddress).(string)
@@ -101,7 +101,7 @@ func resourceCDMRegistrationCreate(ctx context.Context, d *schema.ResourceData, 
 
 	clusterDetails, err := cdmClient.OfflineEntitle(ctx)
 	if err != nil {
-		log.Fatal(err)
+		return diag.FromErr(err)
 	}
 
 	var regConfig []core.NodeRegistrationConfig
@@ -110,12 +110,12 @@ func resourceCDMRegistrationCreate(ctx context.Context, d *schema.ResourceData, 
 	}
 	authToken, _, err := core.Wrap(polarisClient.GQL).RegisterCluster(ctx, true, regConfig, true)
 	if err != nil {
-		log.Fatal(err)
+		return diag.FromErr(err)
 	}
 
 	mode, err := cdmClient.SetRegisteredMode(ctx, authToken)
 	if err != nil {
-		log.Fatal(err)
+		return diag.FromErr(err)
 	}
 
 	d.SetId(d.Get(keyClusterName).(string))
@@ -127,7 +127,7 @@ func resourceCDMRegistrationCreate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourceCDMRegistrationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMRegistrationRead")
+	tflog.Trace(ctx, "resourceCDMRegistrationRead")
 
 	return nil
 }
@@ -135,7 +135,7 @@ func resourceCDMRegistrationRead(ctx context.Context, d *schema.ResourceData, m 
 // Once a Cluster has been registered it cannot be un-registered through the
 // resource, delete simply removes the resource from the local state.
 func resourceCDMRegistrationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] resourceCDMRegistrationDelete")
+	tflog.Trace(ctx, "resourceCDMRegistrationDelete")
 	d.SetId("")
 	return nil
 }

--- a/internal/provider/resource_custom_role.go
+++ b/internal/provider/resource_custom_role.go
@@ -23,9 +23,9 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -113,7 +113,7 @@ func resourceCustomRole() *schema.Resource {
 
 // createCustomRole run the Create operation for the custom role resource.
 func createCustomRole(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] createCustomRole")
+	tflog.Trace(ctx, "createCustomRole")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -136,7 +136,7 @@ func createCustomRole(ctx context.Context, d *schema.ResourceData, m any) diag.D
 
 // readCustomRole run the Read operation for the custom role resource.
 func readCustomRole(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] readCustomRole")
+	tflog.Trace(ctx, "readCustomRole")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -172,7 +172,7 @@ func readCustomRole(ctx context.Context, d *schema.ResourceData, m any) diag.Dia
 
 // updateCustomRole run the Update operation for the custom role resource.
 func updateCustomRole(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] updateCustomRole")
+	tflog.Trace(ctx, "updateCustomRole")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -200,7 +200,7 @@ func updateCustomRole(ctx context.Context, d *schema.ResourceData, m any) diag.D
 
 // deleteCustomRole run the Delete operation for the custom role resource.
 func deleteCustomRole(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] deleteCustomRole")
+	tflog.Trace(ctx, "deleteCustomRole")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_data_center_archival_location_amazon_s3.go
+++ b/internal/provider/resource_data_center_archival_location_amazon_s3.go
@@ -23,9 +23,9 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -336,7 +336,7 @@ func resourceDataCenterArchivalLocationAmazonS3() *schema.Resource {
 }
 
 func dataCenterCreateArchivalLocationAmazonS3(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterCreateArchivalLocationAmazonS3")
+	tflog.Trace(ctx, "dataCenterCreateArchivalLocationAmazonS3")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -386,7 +386,7 @@ func dataCenterCreateArchivalLocationAmazonS3(ctx context.Context, d *schema.Res
 }
 
 func dataCenterReadArchivalLocationAmazonS3(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterReadArchivalLocationAmazonS3")
+	tflog.Trace(ctx, "dataCenterReadArchivalLocationAmazonS3")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -455,7 +455,7 @@ func dataCenterReadArchivalLocationAmazonS3(ctx context.Context, d *schema.Resou
 }
 
 func dataCenterUpdateArchivalLocationAmazonS3(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterUpdateArchivalLocationAmazonS3")
+	tflog.Trace(ctx, "dataCenterUpdateArchivalLocationAmazonS3")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -497,7 +497,7 @@ func dataCenterUpdateArchivalLocationAmazonS3(ctx context.Context, d *schema.Res
 }
 
 func dataCenterDeleteArchivalLocationAmazonS3(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterDeleteArchivalLocationAmazonS3")
+	tflog.Trace(ctx, "dataCenterDeleteArchivalLocationAmazonS3")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_data_center_aws_account.go
+++ b/internal/provider/resource_data_center_aws_account.go
@@ -23,9 +23,9 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -90,7 +90,7 @@ func resourceDataCenterAWSAccount() *schema.Resource {
 }
 
 func dataCenterAWSCreateAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterAWSCreateAccount")
+	tflog.Trace(ctx, "dataCenterAWSCreateAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -113,7 +113,7 @@ func dataCenterAWSCreateAccount(ctx context.Context, d *schema.ResourceData, m i
 }
 
 func dataCenterAWSReadAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterAWSReadAccount")
+	tflog.Trace(ctx, "dataCenterAWSReadAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -147,7 +147,7 @@ func dataCenterAWSReadAccount(ctx context.Context, d *schema.ResourceData, m int
 }
 
 func dataCenterAWSUpdateAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterAWSUpdateAccount")
+	tflog.Trace(ctx, "dataCenterAWSUpdateAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -173,7 +173,7 @@ func dataCenterAWSUpdateAccount(ctx context.Context, d *schema.ResourceData, m i
 }
 
 func dataCenterAWSDeleteAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterAWSDeleteAccount")
+	tflog.Trace(ctx, "dataCenterAWSDeleteAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_data_center_azure_subscription.go
+++ b/internal/provider/resource_data_center_azure_subscription.go
@@ -23,9 +23,9 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -88,7 +88,7 @@ func resourceDataCenterAzureSubscription() *schema.Resource {
 }
 
 func dataCenterAzureCreateSubscription(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterAzureCreateSubscription")
+	tflog.Trace(ctx, "dataCenterAzureCreateSubscription")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -110,7 +110,7 @@ func dataCenterAzureCreateSubscription(ctx context.Context, d *schema.ResourceDa
 }
 
 func dataCenterAzureReadSubscription(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterAzureReadSubscription")
+	tflog.Trace(ctx, "dataCenterAzureReadSubscription")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -147,7 +147,7 @@ func dataCenterAzureReadSubscription(ctx context.Context, d *schema.ResourceData
 }
 
 func dataCenterAzureUpdateSubscription(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterAzureUpdateSubscription")
+	tflog.Trace(ctx, "dataCenterAzureUpdateSubscription")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -172,7 +172,7 @@ func dataCenterAzureUpdateSubscription(ctx context.Context, d *schema.ResourceDa
 }
 
 func dataCenterAzureDeleteSubscription(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] dataCenterAzureDeleteSubscription")
+	tflog.Trace(ctx, "dataCenterAzureDeleteSubscription")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_gcp_project.go
+++ b/internal/provider/resource_gcp_project.go
@@ -23,11 +23,11 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 	"strconv"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -140,7 +140,7 @@ func resourceGcpProject() *schema.Resource {
 // gcpCreateProject run the Create operation for the GCP project resource. This
 // adds the GCP project to the Polaris platform.
 func gcpCreateProject(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] gcpCreateProject")
+	tflog.Trace(ctx, "gcpCreateProject")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -203,7 +203,7 @@ func gcpCreateProject(ctx context.Context, d *schema.ResourceData, m interface{}
 // gcpReadProject run the Read operation for the GCP project resource. This
 // reads the state of the GCP project in Polaris.
 func gcpReadProject(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] gcpReadProject")
+	tflog.Trace(ctx, "gcpReadProject")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -247,7 +247,7 @@ func gcpReadProject(ctx context.Context, d *schema.ResourceData, m interface{}) 
 // gcpUpdateProject run the Update operation for the GCP project resource. This
 // only updates the local delete_snapshots_on_destroy parameter.
 func gcpUpdateProject(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] gcpUpdateProject")
+	tflog.Trace(ctx, "gcpUpdateProject")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -273,7 +273,7 @@ func gcpUpdateProject(ctx context.Context, d *schema.ResourceData, m interface{}
 // gcpDeleteProject run the Delete operation for the GCP project resource. This
 // removes the GCP project from Polaris.
 func gcpDeleteProject(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] gcpDeleteProject")
+	tflog.Trace(ctx, "gcpDeleteProject")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_gcp_project_v0.go
+++ b/internal/provider/resource_gcp_project_v0.go
@@ -23,10 +23,10 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/gcp"
@@ -91,7 +91,7 @@ func resourceGcpProjectV0() *schema.Resource {
 // resourceGcpProjectStateUpgradeV0 simplifies the resource id to consist of
 // only the Polaris cloud account id.
 func resourceGcpProjectStateUpgradeV0(ctx context.Context, state map[string]interface{}, m interface{}) (map[string]interface{}, error) {
-	log.Print("[TRACE] resourceGcpProjectStateUpgradeV0")
+	tflog.Trace(ctx, "resourceGcpProjectStateUpgradeV0")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_gcp_project_v1.go
+++ b/internal/provider/resource_gcp_project_v1.go
@@ -23,9 +23,9 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/gcp"
@@ -90,7 +90,7 @@ func resourceGcpProjectV1() *schema.Resource {
 // resourceAwsAccountStateUpgradeV1 introduces a cloud native protection
 // feature block.
 func resourceGcpProjectStateUpgradeV1(ctx context.Context, state map[string]interface{}, m interface{}) (map[string]interface{}, error) {
-	log.Print("[TRACE] resourceGcpProjectStateUpgradeV1")
+	tflog.Trace(ctx, "resourceGcpProjectStateUpgradeV1")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_gcp_service_account.go
+++ b/internal/provider/resource_gcp_service_account.go
@@ -22,10 +22,10 @@ package provider
 
 import (
 	"context"
-	"log"
 	"path/filepath"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -70,7 +70,7 @@ func resourceGcpServiceAccount() *schema.Resource {
 // gcpCreateServiceAccount run the Create operation for the GCP service account
 // resource. This adds the GCP service account to the Polaris platform.
 func gcpCreateServiceAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] gcpCreateServiceAccount")
+	tflog.Trace(ctx, "gcpCreateServiceAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -99,7 +99,7 @@ func gcpCreateServiceAccount(ctx context.Context, d *schema.ResourceData, m inte
 // gcpReadServiceAccount run the Read operation for the GCP service account
 // resource. This reads the state of the GCP service account in Polaris.
 func gcpReadServiceAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] gcpReadServiceAccount")
+	tflog.Trace(ctx, "gcpReadServiceAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -118,7 +118,7 @@ func gcpReadServiceAccount(ctx context.Context, d *schema.ResourceData, m interf
 // gcpUpdateServiceAccount run the Update operation for the GCP service account
 // resource. This updates the service account in Polaris.
 func gcpUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] gcpUpdateServiceAccount")
+	tflog.Trace(ctx, "gcpUpdateServiceAccount")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -144,7 +144,7 @@ func gcpUpdateServiceAccount(ctx context.Context, d *schema.ResourceData, m inte
 // resource. This only removes the local state of the GCP service account since
 // the service account cannot be removed using the Polaris API.
 func gcpDeleteServiceAccount(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	log.Print("[TRACE] gcpDeleteServiceAccount")
+	tflog.Trace(ctx, "gcpDeleteServiceAccount")
 
 	d.SetId("")
 	return nil

--- a/internal/provider/resource_role_assignment.go
+++ b/internal/provider/resource_role_assignment.go
@@ -23,9 +23,9 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -117,7 +117,7 @@ func resourceRoleAssignment() *schema.Resource {
 }
 
 func createRoleAssignment(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] createRoleAssignment")
+	tflog.Trace(ctx, "createRoleAssignment")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -174,7 +174,7 @@ func createRoleAssignment(ctx context.Context, d *schema.ResourceData, m any) di
 }
 
 func readRoleAssignment(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] readRoleAssignment")
+	tflog.Trace(ctx, "readRoleAssignment")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -241,7 +241,7 @@ func readRoleAssignment(ctx context.Context, d *schema.ResourceData, m any) diag
 }
 
 func updateRoleAssignment(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] updateRoleAssignment")
+	tflog.Trace(ctx, "updateRoleAssignment")
 
 	if !d.HasChanges(keyRoleID, keyRoleIDs) {
 		return nil
@@ -315,7 +315,7 @@ func updateRoleAssignment(ctx context.Context, d *schema.ResourceData, m any) di
 }
 
 func deleteRoleAssignment(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] deleteRoleAssignment")
+	tflog.Trace(ctx, "deleteRoleAssignment")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_role_assignment_v0.go
+++ b/internal/provider/resource_role_assignment_v0.go
@@ -24,8 +24,8 @@ import (
 	"context"
 	"crypto/sha256"
 	"fmt"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/access"
@@ -61,7 +61,7 @@ func resourceRoleAssignmentV0() *schema.Resource {
 // resourceRoleAssignmentStateUpgradeV0 changes the resource ID to be the user
 // ID and not the hash of the user email address and role ID.
 func resourceRoleAssignmentStateUpgradeV0(ctx context.Context, state map[string]any, m any) (map[string]any, error) {
-	log.Print("[TRACE] resourceRoleAssignmentStateUpgradeV0")
+	tflog.Trace(ctx, "resourceRoleAssignmentStateUpgradeV0")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_sla_domain_assignment.go
+++ b/internal/provider/resource_sla_domain_assignment.go
@@ -23,10 +23,10 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -85,7 +85,7 @@ func resourceSLADomainAssignment() *schema.Resource {
 }
 
 func createSLADomainAssignment(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] createSLADomainAssignment")
+	tflog.Trace(ctx, "createSLADomainAssignment")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -124,7 +124,7 @@ func createSLADomainAssignment(ctx context.Context, d *schema.ResourceData, m an
 }
 
 func readSLADomainAssignment(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] readSLADomainAssignment")
+	tflog.Trace(ctx, "readSLADomainAssignment")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -177,7 +177,7 @@ func readSLADomainAssignment(ctx context.Context, d *schema.ResourceData, m any)
 }
 
 func updateSLADomainAssignment(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] updateSLADomainAssignment")
+	tflog.Trace(ctx, "updateSLADomainAssignment")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -239,7 +239,7 @@ func updateSLADomainAssignment(ctx context.Context, d *schema.ResourceData, m an
 }
 
 func deleteSLADomainAssignment(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] deleteSLADomainAssignment")
+	tflog.Trace(ctx, "deleteSLADomainAssignment")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -279,7 +279,7 @@ func deleteSLADomainAssignment(ctx context.Context, d *schema.ResourceData, m an
 }
 
 func waitForAssignment(ctx context.Context, client *polaris.Client, domainID uuid.UUID, objectIDs []uuid.UUID) error {
-	log.Print("[DEBUG] waiting for SLA domain assignment")
+	tflog.Debug(ctx, "waiting for SLA domain assignment")
 
 	for {
 		idSet := make(map[uuid.UUID]struct{}, len(objectIDs))
@@ -298,7 +298,9 @@ func waitForAssignment(ctx context.Context, client *polaris.Client, domainID uui
 			return nil
 		}
 
-		log.Printf("[DEBUG] waiting for SLA domain assignment of %d objects", len(idSet))
+		tflog.Debug(ctx, "waiting for SLA domain assignment", map[string]any{
+			"remaining_objects": len(idSet),
+		})
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -308,7 +310,7 @@ func waitForAssignment(ctx context.Context, client *polaris.Client, domainID uui
 }
 
 func waitForUnassignment(ctx context.Context, client *polaris.Client, domainID uuid.UUID, objectIDs []uuid.UUID) error {
-	log.Print("[DEBUG] waiting for SLA domain unassignment")
+	tflog.Debug(ctx, "waiting for SLA domain unassignment")
 
 	for {
 		idSet := make(map[uuid.UUID]struct{}, len(objectIDs))
@@ -328,7 +330,9 @@ func waitForUnassignment(ctx context.Context, client *polaris.Client, domainID u
 			return nil
 		}
 
-		log.Printf("[DEBUG] waiting for SLA domain unassignment of %d objects", n)
+		tflog.Debug(ctx, "waiting for SLA domain unassignment", map[string]any{
+			"remaining_objects": n,
+		})
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/internal/provider/resource_tag_rule.go
+++ b/internal/provider/resource_tag_rule.go
@@ -24,9 +24,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -119,7 +119,7 @@ func resourceTagRule() *schema.Resource {
 }
 
 func createTagRule(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] createTagRule")
+	tflog.Trace(ctx, "createTagRule")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -160,7 +160,7 @@ func createTagRule(ctx context.Context, d *schema.ResourceData, m any) diag.Diag
 }
 
 func readTagRule(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] readTagRule")
+	tflog.Trace(ctx, "readTagRule")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -217,7 +217,7 @@ func readTagRule(ctx context.Context, d *schema.ResourceData, m any) diag.Diagno
 }
 
 func updateTagRule(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] updateTagRule")
+	tflog.Trace(ctx, "updateTagRule")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -256,7 +256,7 @@ func updateTagRule(ctx context.Context, d *schema.ResourceData, m any) diag.Diag
 }
 
 func deleteTagRule(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] deleteTagRule")
+	tflog.Trace(ctx, "deleteTagRule")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_user.go
+++ b/internal/provider/resource_user.go
@@ -23,10 +23,10 @@ package provider
 import (
 	"context"
 	"errors"
-	"log"
 	"regexp"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -95,7 +95,7 @@ func resourceUser() *schema.Resource {
 }
 
 func createUser(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] createUser")
+	tflog.Trace(ctx, "createUser")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -124,7 +124,7 @@ func createUser(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnos
 }
 
 func readUser(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] readUser")
+	tflog.Trace(ctx, "readUser")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -165,7 +165,7 @@ func readUser(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnosti
 }
 
 func updateUser(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] updateUser")
+	tflog.Trace(ctx, "updateUser")
 
 	client, err := m.(*client).polaris()
 	if err != nil {
@@ -190,7 +190,7 @@ func updateUser(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnos
 }
 
 func deleteUser(ctx context.Context, d *schema.ResourceData, m any) diag.Diagnostics {
-	log.Print("[TRACE] deleteUser")
+	tflog.Trace(ctx, "deleteUser")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/internal/provider/resource_user_v0.go
+++ b/internal/provider/resource_user_v0.go
@@ -23,8 +23,8 @@ package provider
 import (
 	"context"
 	"fmt"
-	"log"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/access"
@@ -72,7 +72,7 @@ func resourceUserV0() *schema.Resource {
 // resourceUserStateUpgradeV0 changes the resource ID to be the user ID and not
 // the user email address.
 func resourceUserStateUpgradeV0(ctx context.Context, state map[string]any, m any) (map[string]any, error) {
-	log.Print("[TRACE] resourceUserStateUpgradeV0")
+	tflog.Trace(ctx, "resourceUserStateUpgradeV0")
 
 	client, err := m.(*client).polaris()
 	if err != nil {

--- a/templates/index.md.tmpl
+++ b/templates/index.md.tmpl
@@ -110,6 +110,29 @@ account behavior:
 * `RUBRIK_POLARIS_ACCOUNT_PASSWORD` - Overrides the password of the local user account.
 * `RUBRIK_POLARIS_ACCOUNT_URL` - Overrides the RSC API URL.
 
+### Terraform Logging Support
+The provider supports Terraform's native logging system (tflog) for improved debugging and troubleshooting. This provides structured logging with better integration into Terraform's logging infrastructure.
+
+#### Terraform Logging Environment Variables
+* `TF_LOG_PROVIDER_POLARIS` - Controls the log level for the Terraform provider itself. Valid log levels are: `TRACE`, `DEBUG`, `INFO`, `WARN`, `ERROR`, and `OFF`. This variable follows Terraform's standard logging conventions.
+* `TF_LOG_PROVIDER_POLARIS_API` - Controls the log level specifically for API calls made by the provider to the Polaris service. This allows you to separately control the verbosity of API-related logging.
+
+#### Usage Examples
+```bash
+# Enable DEBUG logging for the provider, including API calls
+export TF_LOG_PROVIDER_POLARIS=DEBUG
+
+# Enable TRACE logging for API calls only
+export TF_LOG_PROVIDER_POLARIS_API=TRACE
+
+# Enable both provider and API logging at different levels
+export TF_LOG_PROVIDER_POLARIS=INFO
+export TF_LOG_PROVIDER_POLARIS_API=DEBUG
+
+# Direct provider logs to a specific file
+export TF_LOG_PROVIDER_PATH=./polaris-provider.log
+```
+
 ## Example Usage
 
 {{tffile "examples/provider/provider.tf"}}


### PR DESCRIPTION
# Description

Use `tflog` for logging to be able to filter logging.

We now support two env vars for log level control:
* `TF_LOG_PROVIDER_POLARIS` logs from the provider itself.
* `TF_LOG_PROVIDER_POLARIS_API` logs from the underlying Go SDK.

## Related Issue
#139 
