### PR TITLE
Use explict provider name when generating docs

### DIFF
--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/rubrikinc/terraform-provider-polaris/internal/provider"
 )
 
-//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
+//go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-name terraform-provider-polaris
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: provider.Provider,


### PR DESCRIPTION
# Description

tfplugindocs implicitly uses the directory name as provider name, but generated docs are created with `terraform-provider-polaris`. The name is truncated to `polaris` only, but generated files contain the non truncated string too.
