### PR TITLE
CCES NTP servers can now be specified using a FQDN

### DIFF
--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -4,6 +4,10 @@ page_title: "Changelog"
 
 # Changelog
 
+## v1.1.3
+* CCES NTP servers can now be specified using a FQDN. Previously they were required to be IP addresses, now both IP
+  addresses and FQDN are allowed.
+
 ## v1.1.2
 * Update documentation for the `polaris_aws_cnp_account` and `polaris_azure_subscription` resources.
 * Update documentation for the `polaris_aws_cnp_artifacts`, `polaris_aws_cnp_permissions`, and

--- a/docs/resources/cdm_bootstrap.md
+++ b/docs/resources/cdm_bootstrap.md
@@ -61,8 +61,8 @@ resource "polaris_cdm_bootstrap" "default" {
 - `dns_search_domain` (List of String) The search domain that the DNS Service will use to resolve hostnames that are not fully qualified.
 - `management_gateway` (String) IP address assigned to the management network gateway
 - `management_subnet_mask` (String) Subnet mask assigned to the management network.
-- `ntp_server1_name` (String) IP address for NTP server #1.
-- `ntp_server2_name` (String) IP address for NTP server #2.
+- `ntp_server1_name` (String) Name or IP address for NTP server #1.
+- `ntp_server2_name` (String) Name or IP address for NTP server #2.
 
 ### Optional
 

--- a/docs/resources/cdm_bootstrap_cces_aws.md
+++ b/docs/resources/cdm_bootstrap_cces_aws.md
@@ -66,8 +66,8 @@ resource "polaris_cdm_bootstrap_cces_aws" "default" {
 - `dns_search_domain` (List of String) The search domain that the DNS Service will use to resolve hostnames that are not fully qualified.
 - `management_gateway` (String) IP address assigned to the management network gateway
 - `management_subnet_mask` (String) Subnet mask assigned to the management network.
-- `ntp_server1_name` (String) IP address for NTP server #1.
-- `ntp_server2_name` (String) IP address for NTP server #2.
+- `ntp_server1_name` (String) Name or IP address for NTP server #1.
+- `ntp_server2_name` (String) Name or IP address for NTP server #2.
 
 ### Optional
 

--- a/docs/resources/cdm_bootstrap_cces_azure.md
+++ b/docs/resources/cdm_bootstrap_cces_azure.md
@@ -67,8 +67,8 @@ resource "polaris_cdm_bootstrap_cces_azure" "default" {
 - `dns_search_domain` (List of String) The search domain that the DNS Service will use to resolve hostnames that are not fully qualified.
 - `management_gateway` (String) IP address assigned to the management network gateway
 - `management_subnet_mask` (String) Subnet mask assigned to the management network.
-- `ntp_server1_name` (String) IP address for NTP server #1.
-- `ntp_server2_name` (String) IP address for NTP server #2.
+- `ntp_server1_name` (String) Name or IP address for NTP server #1.
+- `ntp_server2_name` (String) Name or IP address for NTP server #2.
 
 ### Optional
 

--- a/internal/provider/resource_cdm_bootstrap.go
+++ b/internal/provider/resource_cdm_bootstrap.go
@@ -148,8 +148,8 @@ func resourceCDMBootstrap() *schema.Resource {
 			keyNTPServer1Name: {
 				Type:         schema.TypeString,
 				Required:     true,
-				Description:  "IP address for NTP server #1.",
-				ValidateFunc: validation.IsIPAddress,
+				Description:  "Name or IP address for NTP server #1.",
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			keyNTPServer1Key: {
 				Type:         schema.TypeString,
@@ -174,8 +174,8 @@ func resourceCDMBootstrap() *schema.Resource {
 			keyNTPServer2Name: {
 				Type:         schema.TypeString,
 				Required:     true,
-				Description:  "IP address for NTP server #2.",
-				ValidateFunc: validation.IsIPAddress,
+				Description:  "Name or IP address for NTP server #2.",
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			keyNTPServer2Key: {
 				Type:         schema.TypeString,

--- a/internal/provider/resource_cdm_bootstrap_cces_aws.go
+++ b/internal/provider/resource_cdm_bootstrap_cces_aws.go
@@ -157,8 +157,8 @@ func resourceCDMBootstrapCCESAWS() *schema.Resource {
 			keyNTPServer1Name: {
 				Type:         schema.TypeString,
 				Required:     true,
-				Description:  "IP address for NTP server #1.",
-				ValidateFunc: validation.IsIPAddress,
+				Description:  "Name or IP address for NTP server #1.",
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			keyNTPServer1Key: {
 				Type:         schema.TypeString,
@@ -183,8 +183,8 @@ func resourceCDMBootstrapCCESAWS() *schema.Resource {
 			keyNTPServer2Name: {
 				Type:         schema.TypeString,
 				Required:     true,
-				Description:  "IP address for NTP server #2.",
-				ValidateFunc: validation.IsIPAddress,
+				Description:  "Name or IP address for NTP server #2.",
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			keyNTPServer2Key: {
 				Type:         schema.TypeString,

--- a/internal/provider/resource_cdm_bootstrap_cces_azure.go
+++ b/internal/provider/resource_cdm_bootstrap_cces_azure.go
@@ -163,8 +163,8 @@ func resourceCDMBootstrapCCESAzure() *schema.Resource {
 			keyNTPServer1Name: {
 				Type:         schema.TypeString,
 				Required:     true,
-				Description:  "IP address for NTP server #1.",
-				ValidateFunc: validation.IsIPAddress,
+				Description:  "Name or IP address for NTP server #1.",
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			keyNTPServer1Key: {
 				Type:         schema.TypeString,
@@ -189,8 +189,8 @@ func resourceCDMBootstrapCCESAzure() *schema.Resource {
 			keyNTPServer2Name: {
 				Type:         schema.TypeString,
 				Required:     true,
-				Description:  "IP address for NTP server #2.",
-				ValidateFunc: validation.IsIPAddress,
+				Description:  "Name or IP address for NTP server #2.",
+				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			keyNTPServer2Key: {
 				Type:         schema.TypeString,

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -4,6 +4,10 @@ page_title: "Changelog"
 
 # Changelog
 
+## v1.1.3
+* CCES NTP servers can now be specified using a FQDN. Previously they were required to be IP addresses, now both IP
+  addresses and FQDN are allowed.
+
 ## v1.1.2
 * Update documentation for the `polaris_aws_cnp_account` and `polaris_azure_subscription` resources.
 * Update documentation for the `polaris_aws_cnp_artifacts`, `polaris_aws_cnp_permissions`, and

--- a/templates/resources/cdm_bootstrap.md.tmpl
+++ b/templates/resources/cdm_bootstrap.md.tmpl
@@ -26,8 +26,8 @@ description: |-
 - `dns_search_domain` (List of String) The search domain that the DNS Service will use to resolve hostnames that are not fully qualified.
 - `management_gateway` (String) IP address assigned to the management network gateway
 - `management_subnet_mask` (String) Subnet mask assigned to the management network.
-- `ntp_server1_name` (String) IP address for NTP server #1.
-- `ntp_server2_name` (String) IP address for NTP server #2.
+- `ntp_server1_name` (String) Name or IP address for NTP server #1.
+- `ntp_server2_name` (String) Name or IP address for NTP server #2.
 
 ### Optional
 

--- a/templates/resources/cdm_bootstrap_cces_aws.md.tmpl
+++ b/templates/resources/cdm_bootstrap_cces_aws.md.tmpl
@@ -27,8 +27,8 @@ description: |-
 - `dns_search_domain` (List of String) The search domain that the DNS Service will use to resolve hostnames that are not fully qualified.
 - `management_gateway` (String) IP address assigned to the management network gateway
 - `management_subnet_mask` (String) Subnet mask assigned to the management network.
-- `ntp_server1_name` (String) IP address for NTP server #1.
-- `ntp_server2_name` (String) IP address for NTP server #2.
+- `ntp_server1_name` (String) Name or IP address for NTP server #1.
+- `ntp_server2_name` (String) Name or IP address for NTP server #2.
 
 ### Optional
 

--- a/templates/resources/cdm_bootstrap_cces_azure.md.tmpl
+++ b/templates/resources/cdm_bootstrap_cces_azure.md.tmpl
@@ -28,8 +28,8 @@ description: |-
 - `dns_search_domain` (List of String) The search domain that the DNS Service will use to resolve hostnames that are not fully qualified.
 - `management_gateway` (String) IP address assigned to the management network gateway
 - `management_subnet_mask` (String) Subnet mask assigned to the management network.
-- `ntp_server1_name` (String) IP address for NTP server #1.
-- `ntp_server2_name` (String) IP address for NTP server #2.
+- `ntp_server1_name` (String) Name or IP address for NTP server #1.
+- `ntp_server2_name` (String) Name or IP address for NTP server #2.
 
 ### Optional
 


### PR DESCRIPTION
# Description

Previously they were required to be IP addresses, now both IP addresses and FQDN are allowed. The change only change the Terraform data validation logic.

## Motivation and Context

The CDM bootstrap API allows both IP addresses and FQDN.

## How Has This Been Tested?

Bootstrapped an Azure CCES cluster specifying a FQDN for both NTP servers.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
