### PR TITLE
Query specific feature flag when needed instead of fetching all

### DIFF
--- a/internal/provider/resource_azure_subscription.go
+++ b/internal/provider/resource_azure_subscription.go
@@ -1448,7 +1448,7 @@ func upgradeSQLDBFeatureToUseResourceGroup(ctx context.Context, client *client, 
 
 	// Check if the SQL DB Copy Backup feature flag is enabled for the account.
 	// We only need to upgrade accounts which has the feature flag enabled.
-	if !client.flags["CNP_AZURE_SQL_DB_COPY_BACKUP"] {
+	if !client.flag(ctx, "CNP_AZURE_SQL_DB_COPY_BACKUP") {
 		tflog.Debug(ctx, "skipping Azure SQL DB Protection feature upgrade: feature flag CNP_AZURE_SQL_DB_COPY_BACKUP is not enabled")
 		return false, nil
 	}


### PR DESCRIPTION
This change drops the query of _all_ feature flags, and instead query _the specific ones_ when needed.

Running only the Azure tests with trace logging previously generated about 35MB logs. More than 90% of that was the feature flag request/response as we queried all flags 58 times.

The produced log is now less than 10% of before, making debugging easier.