### PR TITLE
Fix MI upgrade to include permission groups in SDK call

### DIFF
--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -4,6 +4,17 @@ page_title: "Changelog"
 
 # Changelog
 
+## v1.6.2
+* Fix managed identity upgrade for the `sql_db_protection` block in the `polaris_azure_subscription` resource. The
+  `upgradeFeatureToUseManagedIdentity` function was not including permission groups in the SDK call, causing the Go SDK
+  to select the legacy GraphQL query variant. This silently dropped the managed identity details (UMI), bypassing
+  backend validation and resulting in subscriptions upgraded to `BACKUP_V2` without the required UMI mapping.
+* Read back `user_assigned_managed_identity_name` and `user_assigned_managed_identity_principal_id` from the API during
+  `terraform plan` and `terraform apply` for the `sql_db_protection` block. Previously these fields were write-only and
+  not refreshed from remote state.
+* Require `cloud_discovery` for `polaris_refresh` when discovery onboarding is enabled.
+* Poll SLA domain object count before delete for eventual consistency.
+
 ## v1.6.1
 * Re-release of v1.6.0 due to a GoReleaser bug that caused the v1.6.0 release to fail.
 

--- a/docs/guides/upgrade_guide_v1.6.0.md
+++ b/docs/guides/upgrade_guide_v1.6.0.md
@@ -4,61 +4,6 @@ page_title: "Upgrade Guide: v1.6.0"
 
 # Upgrade Guide v1.6.0
 
-## New Features
-
-### polaris_sso_group resource
-
-The new `polaris_sso_group` resource creates and manages SSO groups in RSC. It supports assigning roles to SSO groups
-and importing existing groups using the `<group_name>:<identity_provider_id>` format.
-
-```terraform
-data "polaris_identity_provider" "example" {
-  name = "My IdP"
-}
-
-resource "polaris_sso_group" "example" {
-  group_name     = "mygroup"
-  auth_domain_id = data.polaris_identity_provider.example.identity_provider_id
-
-  role_ids = [
-    polaris_custom_role.viewer.id,
-  ]
-}
-```
-
-For more details, see the [polaris_sso_group documentation](../resources/sso_group.md).
-
-### polaris_identity_provider data source
-
-The new `polaris_identity_provider` data source looks up identity providers configured in RSC by ID or name. This is
-useful for referencing identity providers when configuring SSO group resources.
-
-For more details, see the [polaris_identity_provider documentation](../data-sources/identity_provider.md).
-
-### polaris_refresh resource
-
-The new `polaris_refresh` resource polls until an account or subscription's inventory refresh in RSC is newer than a
-given timestamp. This ensures leaf objects like VMs and EC2 instances are discoverable via `polaris_object` after
-onboarding.
-
-For more details, see the [polaris_refresh documentation](../resources/refresh.md).
-
-### polaris_aws_account: role chaining support
-
-The `polaris_aws_account` resource now supports the `role_chaining` feature block for cross-account role chaining. The
-feature is mutually exclusive with all other features. A new `role_chaining_account_id` field allows referencing the RSC
-cloud account ID of an account with the Role Chaining feature enabled.
-
-For more details, see the [polaris_aws_account documentation](../resources/aws_account.md).
-
-### polaris_object: additional workload types
-
-The `polaris_object` data source now supports `AwsNativeEbsVolume`, `AwsNativeEc2Instance`, `AwsNativeRdsInstance` and
-`AzureNativeVirtualMachine` workload types. These workload-level types use server-side filters to exclude inactive
-objects.
-
-For more details, see the [polaris_object documentation](../data-sources/object.md).
-
 ## Before Upgrading
 
 Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
@@ -130,3 +75,58 @@ resource "polaris_aws_account" "example" {
   }
 }
 ```
+
+## New Features
+
+### polaris_sso_group resource
+
+The new `polaris_sso_group` resource creates and manages SSO groups in RSC. It supports assigning roles to SSO groups
+and importing existing groups using the `<group_name>:<identity_provider_id>` format.
+
+```terraform
+data "polaris_identity_provider" "example" {
+  name = "My IdP"
+}
+
+resource "polaris_sso_group" "example" {
+  group_name     = "mygroup"
+  auth_domain_id = data.polaris_identity_provider.example.identity_provider_id
+
+  role_ids = [
+    polaris_custom_role.viewer.id,
+  ]
+}
+```
+
+For more details, see the [polaris_sso_group documentation](../resources/sso_group.md).
+
+### polaris_identity_provider data source
+
+The new `polaris_identity_provider` data source looks up identity providers configured in RSC by ID or name. This is
+useful for referencing identity providers when configuring SSO group resources.
+
+For more details, see the [polaris_identity_provider documentation](../data-sources/identity_provider.md).
+
+### polaris_refresh resource
+
+The new `polaris_refresh` resource polls until an account or subscription's inventory refresh in RSC is newer than a
+given timestamp. This ensures leaf objects like VMs and EC2 instances are discoverable via `polaris_object` after
+onboarding.
+
+For more details, see the [polaris_refresh documentation](../resources/refresh.md).
+
+### polaris_aws_account: role chaining support
+
+The `polaris_aws_account` resource now supports the `role_chaining` feature block for cross-account role chaining. The
+feature is mutually exclusive with all other features. A new `role_chaining_account_id` field allows referencing the RSC
+cloud account ID of an account with the Role Chaining feature enabled.
+
+For more details, see the [polaris_aws_account documentation](../resources/aws_account.md).
+
+### polaris_object: additional workload types
+
+The `polaris_object` data source now supports `AwsNativeEbsVolume`, `AwsNativeEc2Instance`, `AwsNativeRdsInstance` and
+`AzureNativeVirtualMachine` workload types. These workload-level types use server-side filters to exclude inactive
+objects.
+
+For more details, see the [polaris_object documentation](../data-sources/object.md).

--- a/docs/guides/upgrade_guide_v1.6.2.md
+++ b/docs/guides/upgrade_guide_v1.6.2.md
@@ -4,26 +4,6 @@ page_title: "Upgrade Guide: v1.6.2"
 
 # Upgrade Guide v1.6.2
 
-## Bug Fixes
-
-### polaris_azure_subscription: managed identity upgrade fix
-
-The `upgradeFeatureToUseManagedIdentity` function was not including permission groups from the Terraform configuration
-when calling the Go SDK. This caused the SDK to select the legacy GraphQL query variant (using the deprecated `feature`
-field), which silently dropped the `FeatureSpecificInfo` payload containing the user-assigned managed identity (UMI)
-details. As a result, subscriptions upgraded to `BACKUP_V2` were missing the required UMI mapping.
-
-This fix extracts permission groups from the configuration block before calling the SDK, matching the pattern already
-used in `upgradeSQLDBFeatureToUseResourceGroup`. The SDK now selects the correct query variant (`featureToUpgrade`),
-which carries both permission groups and the managed identity input through to backend validation.
-
-### polaris_azure_subscription: managed identity state refresh
-
-The `user_assigned_managed_identity_name` and `user_assigned_managed_identity_principal_id` fields in the
-`sql_db_protection` block are now read back from the API during `terraform plan` and `terraform apply`. Previously
-these fields were write-only and not refreshed from remote state, which could cause unnecessary diffs or mask
-configuration drift.
-
 ## Before Upgrading
 
 Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
@@ -61,3 +41,23 @@ this is expected as the provider now reads these values from the API. Proceed by
 % terraform apply -refresh-only
 ```
 This will read the remote state of the resources and migrate the local Terraform state to the v1.6.2 version.
+
+## Bug Fixes
+
+### polaris_azure_subscription: managed identity upgrade fix
+
+The `upgradeFeatureToUseManagedIdentity` function was not including permission groups from the Terraform configuration
+when calling the Go SDK. This caused the SDK to select the legacy GraphQL query variant (using the deprecated `feature`
+field), which silently dropped the `FeatureSpecificInfo` payload containing the user-assigned managed identity (UMI)
+details. As a result, subscriptions upgraded to `BACKUP_V2` were missing the required UMI mapping.
+
+This fix extracts permission groups from the configuration block before calling the SDK, matching the pattern already
+used in `upgradeSQLDBFeatureToUseResourceGroup`. The SDK now selects the correct query variant (`featureToUpgrade`),
+which carries both permission groups and the managed identity input through to backend validation.
+
+### polaris_azure_subscription: managed identity state refresh
+
+The `user_assigned_managed_identity_name` and `user_assigned_managed_identity_principal_id` fields in the
+`sql_db_protection` block are now read back from the API during `terraform plan` and `terraform apply`. Previously
+these fields were write-only and not refreshed from remote state, which could cause unnecessary diffs or mask
+configuration drift.

--- a/docs/guides/upgrade_guide_v1.6.2.md
+++ b/docs/guides/upgrade_guide_v1.6.2.md
@@ -1,0 +1,63 @@
+---
+page_title: "Upgrade Guide: v1.6.2"
+---
+
+# Upgrade Guide v1.6.2
+
+## Bug Fixes
+
+### polaris_azure_subscription: managed identity upgrade fix
+
+The `upgradeFeatureToUseManagedIdentity` function was not including permission groups from the Terraform configuration
+when calling the Go SDK. This caused the SDK to select the legacy GraphQL query variant (using the deprecated `feature`
+field), which silently dropped the `FeatureSpecificInfo` payload containing the user-assigned managed identity (UMI)
+details. As a result, subscriptions upgraded to `BACKUP_V2` were missing the required UMI mapping.
+
+This fix extracts permission groups from the configuration block before calling the SDK, matching the pattern already
+used in `upgradeSQLDBFeatureToUseResourceGroup`. The SDK now selects the correct query variant (`featureToUpgrade`),
+which carries both permission groups and the managed identity input through to backend validation.
+
+### polaris_azure_subscription: managed identity state refresh
+
+The `user_assigned_managed_identity_name` and `user_assigned_managed_identity_principal_id` fields in the
+`sql_db_protection` block are now read back from the API during `terraform plan` and `terraform apply`. Previously
+these fields were write-only and not refreshed from remote state, which could cause unnecessary diffs or mask
+configuration drift.
+
+## Before Upgrading
+
+Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
+provider. If you have existing `polaris_azure_subscription` resources with the `sql_db_protection` block and
+user-assigned managed identity fields, upgrading to v1.6.2 may show a diff on the first `terraform plan` as the
+provider reads back the managed identity state from the API. This is expected and can be resolved by running
+`terraform apply -refresh-only`.
+
+## How to Upgrade
+
+Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.6.2 release. One
+way of doing this is by using the pessimistic constraint operator `~>`, which allows Terraform to upgrade to the latest
+release within the same minor version:
+```terraform
+terraform {
+  required_providers {
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "~> 1.6.0"
+    }
+  }
+}
+```
+Next, upgrade the provider to the new version by running:
+```shell
+% terraform init -upgrade
+```
+After the provider has been updated, validate the correctness of the Terraform configuration files by running:
+```shell
+% terraform plan
+```
+If you see a diff on `user_assigned_managed_identity_name` or `user_assigned_managed_identity_principal_id` fields,
+this is expected as the provider now reads these values from the API. Proceed by running:
+```shell
+% terraform apply -refresh-only
+```
+This will read the remote state of the resources and migrate the local Terraform state to the v1.6.2 version.

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.22.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.1-0.20260402093556-3bf40f2e3cb6
+	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.1-0.20260402093556-3bf40f2e3cb6 h1:UhgK2CrmhE1sJ91wuBRAGKG8mAUrj82y1pV1v7XkLLY=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.1-0.20260402093556-3bf40f2e3cb6/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.1 h1:hMdvkiPZfae0DLwl7wTlErAmHJBNqUSV2LvOmHzu0dE=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.1/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/internal/provider/resource_azure_subscription.go
+++ b/internal/provider/resource_azure_subscription.go
@@ -1826,6 +1826,10 @@ func upgradeFeatureToUseManagedIdentity(ctx context.Context, client *client, clo
 		},
 	}
 
+	if pgs, ok := azureFeaturePermissionGroups(block); ok {
+		feature = feature.WithPermissionGroups(pgs...)
+	}
+
 	if err := gqlazure.Wrap(polarisClient.GQL).UpgradeCloudAccountPermissionsWithoutOAuth(ctx, gqlazure.PermissionUpgrade{
 		CloudAccountID:      cloudAccountID,
 		Feature:             feature,

--- a/internal/provider/resource_azure_subscription.go
+++ b/internal/provider/resource_azure_subscription.go
@@ -1532,6 +1532,11 @@ func updateAzureFeatureState(d *schema.ResourceData, key string, feature azure.F
 		block[keyResourceGroupTags] = tags
 	}
 
+	if feature.Equal(core.FeatureAzureSQLDBProtection) {
+		block[keyUserAssignedManagedIdentityName] = feature.UserAssignedManagedIdentity.Name
+		block[keyUserAssignedManagedIdentityPrincipalID] = feature.UserAssignedManagedIdentity.PrincipalID
+	}
+
 	if err := d.Set(key, []any{block}); err != nil {
 		return err
 	}

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -4,6 +4,17 @@ page_title: "Changelog"
 
 # Changelog
 
+## v1.6.2
+* Fix managed identity upgrade for the `sql_db_protection` block in the `polaris_azure_subscription` resource. The
+  `upgradeFeatureToUseManagedIdentity` function was not including permission groups in the SDK call, causing the Go SDK
+  to select the legacy GraphQL query variant. This silently dropped the managed identity details (UMI), bypassing
+  backend validation and resulting in subscriptions upgraded to `BACKUP_V2` without the required UMI mapping.
+* Read back `user_assigned_managed_identity_name` and `user_assigned_managed_identity_principal_id` from the API during
+  `terraform plan` and `terraform apply` for the `sql_db_protection` block. Previously these fields were write-only and
+  not refreshed from remote state.
+* Require `cloud_discovery` for `polaris_refresh` when discovery onboarding is enabled.
+* Poll SLA domain object count before delete for eventual consistency.
+
 ## v1.6.1
 * Re-release of v1.6.0 due to a GoReleaser bug that caused the v1.6.0 release to fail.
 

--- a/templates/guides/upgrade_guide_v1.6.0.md.tmpl
+++ b/templates/guides/upgrade_guide_v1.6.0.md.tmpl
@@ -4,61 +4,6 @@ page_title: "Upgrade Guide: v1.6.0"
 
 # Upgrade Guide v1.6.0
 
-## New Features
-
-### polaris_sso_group resource
-
-The new `polaris_sso_group` resource creates and manages SSO groups in RSC. It supports assigning roles to SSO groups
-and importing existing groups using the `<group_name>:<identity_provider_id>` format.
-
-```terraform
-data "polaris_identity_provider" "example" {
-  name = "My IdP"
-}
-
-resource "polaris_sso_group" "example" {
-  group_name     = "mygroup"
-  auth_domain_id = data.polaris_identity_provider.example.identity_provider_id
-
-  role_ids = [
-    polaris_custom_role.viewer.id,
-  ]
-}
-```
-
-For more details, see the [polaris_sso_group documentation](../resources/sso_group.md).
-
-### polaris_identity_provider data source
-
-The new `polaris_identity_provider` data source looks up identity providers configured in RSC by ID or name. This is
-useful for referencing identity providers when configuring SSO group resources.
-
-For more details, see the [polaris_identity_provider documentation](../data-sources/identity_provider.md).
-
-### polaris_refresh resource
-
-The new `polaris_refresh` resource polls until an account or subscription's inventory refresh in RSC is newer than a
-given timestamp. This ensures leaf objects like VMs and EC2 instances are discoverable via `polaris_object` after
-onboarding.
-
-For more details, see the [polaris_refresh documentation](../resources/refresh.md).
-
-### polaris_aws_account: role chaining support
-
-The `polaris_aws_account` resource now supports the `role_chaining` feature block for cross-account role chaining. The
-feature is mutually exclusive with all other features. A new `role_chaining_account_id` field allows referencing the RSC
-cloud account ID of an account with the Role Chaining feature enabled.
-
-For more details, see the [polaris_aws_account documentation](../resources/aws_account.md).
-
-### polaris_object: additional workload types
-
-The `polaris_object` data source now supports `AwsNativeEbsVolume`, `AwsNativeEc2Instance`, `AwsNativeRdsInstance` and
-`AzureNativeVirtualMachine` workload types. These workload-level types use server-side filters to exclude inactive
-objects.
-
-For more details, see the [polaris_object documentation](../data-sources/object.md).
-
 ## Before Upgrading
 
 Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
@@ -130,3 +75,58 @@ resource "polaris_aws_account" "example" {
   }
 }
 ```
+
+## New Features
+
+### polaris_sso_group resource
+
+The new `polaris_sso_group` resource creates and manages SSO groups in RSC. It supports assigning roles to SSO groups
+and importing existing groups using the `<group_name>:<identity_provider_id>` format.
+
+```terraform
+data "polaris_identity_provider" "example" {
+  name = "My IdP"
+}
+
+resource "polaris_sso_group" "example" {
+  group_name     = "mygroup"
+  auth_domain_id = data.polaris_identity_provider.example.identity_provider_id
+
+  role_ids = [
+    polaris_custom_role.viewer.id,
+  ]
+}
+```
+
+For more details, see the [polaris_sso_group documentation](../resources/sso_group.md).
+
+### polaris_identity_provider data source
+
+The new `polaris_identity_provider` data source looks up identity providers configured in RSC by ID or name. This is
+useful for referencing identity providers when configuring SSO group resources.
+
+For more details, see the [polaris_identity_provider documentation](../data-sources/identity_provider.md).
+
+### polaris_refresh resource
+
+The new `polaris_refresh` resource polls until an account or subscription's inventory refresh in RSC is newer than a
+given timestamp. This ensures leaf objects like VMs and EC2 instances are discoverable via `polaris_object` after
+onboarding.
+
+For more details, see the [polaris_refresh documentation](../resources/refresh.md).
+
+### polaris_aws_account: role chaining support
+
+The `polaris_aws_account` resource now supports the `role_chaining` feature block for cross-account role chaining. The
+feature is mutually exclusive with all other features. A new `role_chaining_account_id` field allows referencing the RSC
+cloud account ID of an account with the Role Chaining feature enabled.
+
+For more details, see the [polaris_aws_account documentation](../resources/aws_account.md).
+
+### polaris_object: additional workload types
+
+The `polaris_object` data source now supports `AwsNativeEbsVolume`, `AwsNativeEc2Instance`, `AwsNativeRdsInstance` and
+`AzureNativeVirtualMachine` workload types. These workload-level types use server-side filters to exclude inactive
+objects.
+
+For more details, see the [polaris_object documentation](../data-sources/object.md).

--- a/templates/guides/upgrade_guide_v1.6.2.md.tmpl
+++ b/templates/guides/upgrade_guide_v1.6.2.md.tmpl
@@ -4,26 +4,6 @@ page_title: "Upgrade Guide: v1.6.2"
 
 # Upgrade Guide v1.6.2
 
-## Bug Fixes
-
-### polaris_azure_subscription: managed identity upgrade fix
-
-The `upgradeFeatureToUseManagedIdentity` function was not including permission groups from the Terraform configuration
-when calling the Go SDK. This caused the SDK to select the legacy GraphQL query variant (using the deprecated `feature`
-field), which silently dropped the `FeatureSpecificInfo` payload containing the user-assigned managed identity (UMI)
-details. As a result, subscriptions upgraded to `BACKUP_V2` were missing the required UMI mapping.
-
-This fix extracts permission groups from the configuration block before calling the SDK, matching the pattern already
-used in `upgradeSQLDBFeatureToUseResourceGroup`. The SDK now selects the correct query variant (`featureToUpgrade`),
-which carries both permission groups and the managed identity input through to backend validation.
-
-### polaris_azure_subscription: managed identity state refresh
-
-The `user_assigned_managed_identity_name` and `user_assigned_managed_identity_principal_id` fields in the
-`sql_db_protection` block are now read back from the API during `terraform plan` and `terraform apply`. Previously
-these fields were write-only and not refreshed from remote state, which could cause unnecessary diffs or mask
-configuration drift.
-
 ## Before Upgrading
 
 Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
@@ -61,3 +41,23 @@ this is expected as the provider now reads these values from the API. Proceed by
 % terraform apply -refresh-only
 ```
 This will read the remote state of the resources and migrate the local Terraform state to the v1.6.2 version.
+
+## Bug Fixes
+
+### polaris_azure_subscription: managed identity upgrade fix
+
+The `upgradeFeatureToUseManagedIdentity` function was not including permission groups from the Terraform configuration
+when calling the Go SDK. This caused the SDK to select the legacy GraphQL query variant (using the deprecated `feature`
+field), which silently dropped the `FeatureSpecificInfo` payload containing the user-assigned managed identity (UMI)
+details. As a result, subscriptions upgraded to `BACKUP_V2` were missing the required UMI mapping.
+
+This fix extracts permission groups from the configuration block before calling the SDK, matching the pattern already
+used in `upgradeSQLDBFeatureToUseResourceGroup`. The SDK now selects the correct query variant (`featureToUpgrade`),
+which carries both permission groups and the managed identity input through to backend validation.
+
+### polaris_azure_subscription: managed identity state refresh
+
+The `user_assigned_managed_identity_name` and `user_assigned_managed_identity_principal_id` fields in the
+`sql_db_protection` block are now read back from the API during `terraform plan` and `terraform apply`. Previously
+these fields were write-only and not refreshed from remote state, which could cause unnecessary diffs or mask
+configuration drift.

--- a/templates/guides/upgrade_guide_v1.6.2.md.tmpl
+++ b/templates/guides/upgrade_guide_v1.6.2.md.tmpl
@@ -1,0 +1,63 @@
+---
+page_title: "Upgrade Guide: v1.6.2"
+---
+
+# Upgrade Guide v1.6.2
+
+## Bug Fixes
+
+### polaris_azure_subscription: managed identity upgrade fix
+
+The `upgradeFeatureToUseManagedIdentity` function was not including permission groups from the Terraform configuration
+when calling the Go SDK. This caused the SDK to select the legacy GraphQL query variant (using the deprecated `feature`
+field), which silently dropped the `FeatureSpecificInfo` payload containing the user-assigned managed identity (UMI)
+details. As a result, subscriptions upgraded to `BACKUP_V2` were missing the required UMI mapping.
+
+This fix extracts permission groups from the configuration block before calling the SDK, matching the pattern already
+used in `upgradeSQLDBFeatureToUseResourceGroup`. The SDK now selects the correct query variant (`featureToUpgrade`),
+which carries both permission groups and the managed identity input through to backend validation.
+
+### polaris_azure_subscription: managed identity state refresh
+
+The `user_assigned_managed_identity_name` and `user_assigned_managed_identity_principal_id` fields in the
+`sql_db_protection` block are now read back from the API during `terraform plan` and `terraform apply`. Previously
+these fields were write-only and not refreshed from remote state, which could cause unnecessary diffs or mask
+configuration drift.
+
+## Before Upgrading
+
+Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
+provider. If you have existing `polaris_azure_subscription` resources with the `sql_db_protection` block and
+user-assigned managed identity fields, upgrading to v1.6.2 may show a diff on the first `terraform plan` as the
+provider reads back the managed identity state from the API. This is expected and can be resolved by running
+`terraform apply -refresh-only`.
+
+## How to Upgrade
+
+Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.6.2 release. One
+way of doing this is by using the pessimistic constraint operator `~>`, which allows Terraform to upgrade to the latest
+release within the same minor version:
+```terraform
+terraform {
+  required_providers {
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "~> 1.6.0"
+    }
+  }
+}
+```
+Next, upgrade the provider to the new version by running:
+```shell
+% terraform init -upgrade
+```
+After the provider has been updated, validate the correctness of the Terraform configuration files by running:
+```shell
+% terraform plan
+```
+If you see a diff on `user_assigned_managed_identity_name` or `user_assigned_managed_identity_principal_id` fields,
+this is expected as the provider now reads these values from the API. Proceed by running:
+```shell
+% terraform apply -refresh-only
+```
+This will read the remote state of the resources and migrate the local Terraform state to the v1.6.2 version.


### PR DESCRIPTION
## Summary

- `upgradeFeatureToUseManagedIdentity` was not extracting permission groups from the Terraform config block before calling the Go SDK
- Without permission groups, the SDK selected the legacy GraphQL query using the deprecated `feature` field, which silently dropped `FeatureSpecificInfo` (UMI details)
- The backend validator only checks the `features_to_upgrade` proto field (populated by the `featureToUpgrade` GraphQL field), so UMI validation was bypassed entirely
- This led to subscriptions being upgraded to `BACKUP_V2` without the required UMI mapping 
- Fix: extract permission groups from the config block using `azureFeaturePermissionGroups()`, matching the pattern already used in `upgradeSQLDBFeatureToUseResourceGroup`

## Test plan

- [ ] Verify `upgradeFeatureToUseManagedIdentity` now sends the `featureToUpgrade` query variant (with permission groups and `specificFeatureInput`) instead of the legacy `feature` variant
- [ ] Test Azure SQL DB Protection feature upgrade with UMI details and permission groups (`BASIC`, `RECOVERY`, `BACKUP_V2`)
- [ ] Confirm UMI mapping is created in the cloud accounts page after upgrade
