### PR TITLE
Exclude SBOMs from the SHA256SUMS checksum file

### DIFF
--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -26,7 +26,7 @@ jobs:
           version: v2.14.3
           args: release --clean --snapshot --skip=sign,publish
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.0
         with:
           name: dist
           path: dist/

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -30,3 +30,4 @@ jobs:
         with:
           name: dist
           path: dist/
+          retention-days: 1

--- a/.github/workflows/release-dry-run.yml
+++ b/.github/workflows/release-dry-run.yml
@@ -25,3 +25,8 @@ jobs:
         with:
           version: v2.14.3
           args: release --clean --snapshot --skip=sign,publish
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -30,8 +30,11 @@ archives:
   - formats: zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 sboms:
-  - artifacts: archive
+  - id: sbom
+    artifacts: archive
 checksum:
+  ids:
+    - default
   extra_files:
     - glob: 'terraform-registry-manifest.json'
       name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'


### PR DESCRIPTION
# Description

The Terraform Registry flags `.json` files listed in SHA256SUMS as invalid release assets. This has been happening since v1.6.0 when SBOM generation was added in #400. The SBOM `.sbom.json` files are included in SHA256SUMS by default because GoReleaser treats them as release-uploadable artifacts and the checksum pipe includes all such artifacts when no ID filter is set.

## Motivation and Context

The Terraform Registry shows a "Some release assets are invalid" warning for every release that includes `.sbom.json` entries in SHA256SUMS. We want to keep generating SBOMs as release artifacts, but the registry only expects `.zip` and `_manifest.json` entries in the checksum file.

The fix gives the SBOM config block a distinct ID (`sbom`) and sets `checksum.ids: [default]` so only the archive artifacts (which have the implicit `default` ID) are checksummed. The manifest is unaffected since it's added via `extra_files`, which is processed independently of the `ids` filter.

This PR also adds an artifact upload step to the `release-dry-run` workflow so that the generated `dist/` directory (including SHA256SUMS) can be downloaded and inspected after a dry-run.

## How Has This Been Tested?

* Trigger the `release-dry-run` workflow on this branch and verify that the generated SHA256SUMS file contains only `.zip` and `_manifest.json` entries, with no `.sbom.json` entries.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.