### PR TITLE
Fix storage_account_name_prefix max length in azure archival location

### DIFF
--- a/docs/data-sources/azure_archival_location.md
+++ b/docs/data-sources/azure_archival_location.md
@@ -48,7 +48,7 @@ data "polaris_azure_archival_location" "archival_location" {
 - `customer_managed_key` (Set of Object) Customer managed storage encryption. For `SPECIFIC_REGION`, a customer managed key for the specified region will be returned. For `SOURCE_REGION`, a customer managed key for each specified region will be returned, for other regions, data will be encrypted using platform managed keys. (see [below for nested schema](#nestedatt--customer_managed_key))
 - `location_template` (String) RSC location template. If a storage account region was specified, it will be `SPECIFIC_REGION`, otherwise `SOURCE_REGION`.
 - `redundancy` (String) Azure storage redundancy. Possible values are `GRS`, `GZRS`, `LRS`, `RA_GRS`, `RA_GZRS` and `ZRS`. Default value is `LRS`.
-- `storage_account_name_prefix` (String) Azure storage account name prefix. The storage account name prefix cannot be longer than 14 characters and can only consist of numbers and lower case letters.
+- `storage_account_name_prefix` (String) Azure storage account name prefix. For `SOURCE_REGION`, the prefix cannot be longer than 16 characters. For `SPECIFIC_REGION`, the name cannot be longer than 24 characters. The value can only consist of numbers and lower case letters.
 - `storage_account_region` (String) Azure region to store the snapshots in (`SPECIFIC_REGION`). If not specified, the snapshots will be stored in the same region as the workload (`SOURCE_REGION`).
 - `storage_account_tags` (Map of String) Azure storage account tags. Each tag will be added to the storage account created by RSC.
 - `storage_tier` (String) Azure storage tier. Possible values are `COOL` and `HOT`. Default value is `COOL`.

--- a/docs/resources/azure_archival_location.md
+++ b/docs/resources/azure_archival_location.md
@@ -87,7 +87,7 @@ resource "polaris_azure_archival_location" "archival_location" {
 
 - `cloud_account_id` (String) RSC cloud account ID (UUID). Changing this forces a new resource to be created.
 - `name` (String) Cloud native archival location name.
-- `storage_account_name_prefix` (String) Azure storage account name prefix. The storage account name prefix cannot be longer than 14 characters and can only consist of numbers and lower case letters. Changing this forces a new resource to be created.
+- `storage_account_name_prefix` (String) Azure storage account name prefix. When `storage_account_region` is not specified (`SOURCE_REGION`), the prefix cannot be longer than 16 characters. When `storage_account_region` is specified (`SPECIFIC_REGION`), the name cannot be longer than 24 characters. The value can only consist of numbers and lower case letters. Changing this forces a new resource to be created.
 
 ### Optional
 

--- a/internal/provider/data_source_azure_archival_location.go
+++ b/internal/provider/data_source_azure_archival_location.go
@@ -116,8 +116,9 @@ func dataSourceAzureArchivalLocation() *schema.Resource {
 			keyStorageAccountNamePrefix: {
 				Type:     schema.TypeString,
 				Computed: true,
-				Description: "Azure storage account name prefix. The storage account name prefix cannot be longer " +
-					"than 14 characters and can only consist of numbers and lower case letters.",
+				Description: "Azure storage account name prefix. For `SOURCE_REGION`, the prefix cannot be " +
+					"longer than 16 characters. For `SPECIFIC_REGION`, the name cannot be longer than 24 " +
+					"characters. The value can only consist of numbers and lower case letters.",
 			},
 			keyStorageAccountRegion: {
 				Type:     schema.TypeString,

--- a/internal/provider/resource_azure_archival_location.go
+++ b/internal/provider/resource_azure_archival_location.go
@@ -23,6 +23,7 @@ package provider
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
 
 	"github.com/google/uuid"
@@ -66,8 +67,8 @@ func resourceAzureArchivalLocation() *schema.Resource {
 		ReadContext:   azureReadArchivalLocation,
 		UpdateContext: azureUpdateArchivalLocation,
 		DeleteContext: azureDeleteArchivalLocation,
-
-		Description: description(resourceAzureArchivalLocationDescription),
+		CustomizeDiff: azureCustomizeDiffArchivalLocation,
+		Description:   description(resourceAzureArchivalLocationDescription),
 		Schema: map[string]*schema.Schema{
 			keyID: {
 				Type:        schema.TypeString,
@@ -133,10 +134,11 @@ func resourceAzureArchivalLocation() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
-				Description: "Azure storage account name prefix. The storage account name prefix cannot be longer " +
-					"than 14 characters and can only consist of numbers and lower case letters. Changing this forces " +
-					"a new resource to be created.",
-				ValidateFunc: validation.All(validation.StringLenBetween(1, 14),
+				Description: "Azure storage account name prefix. When `storage_account_region` is not specified " +
+					"(`SOURCE_REGION`), the prefix cannot be longer than 16 characters. When `storage_account_region` " +
+					"is specified (`SPECIFIC_REGION`), the name cannot be longer than 24 characters. The value can " +
+					"only consist of numbers and lower case letters. Changing this forces a new resource to be created.",
+				ValidateFunc: validation.All(validation.StringLenBetween(1, 24),
 					validation.StringMatch(regexp.MustCompile("^[a-z0-9]*$"),
 						"storage account name may only contain numbers and lowercase letters")),
 			},
@@ -321,6 +323,29 @@ func azureDeleteArchivalLocation(ctx context.Context, d *schema.ResourceData, m 
 	// Delete the Azure cloud native archival location.
 	if err := archival.Wrap(client).DeleteTargetMapping(ctx, targetMappingID); err != nil {
 		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+// azureCustomizeDiffArchivalLocation validates changes to the Azure archival
+// location resource.
+func azureCustomizeDiffArchivalLocation(ctx context.Context, diff *schema.ResourceDiff, m any) error {
+	tflog.Trace(ctx, "azureCustomizeDiffArchivalLocation")
+
+	name := diff.Get(keyStorageAccountNamePrefix).(string)
+	if _, ok := diff.GetOk(keyStorageAccountRegion); ok {
+		// SPECIFIC_REGION: the name is used directly as the Azure storage
+		// account name, so it must be between 3 and 24 characters.
+		if len(name) < 3 {
+			return fmt.Errorf("storage_account_name_prefix must be at least 3 characters when storage_account_region is specified")
+		}
+	} else {
+		// SOURCE_REGION: an 8-character random UID is appended to the
+		// prefix, so it must not be longer than 16 characters.
+		if len(name) > 16 {
+			return fmt.Errorf("storage_account_name_prefix must not be longer than 16 characters when storage_account_region is not specified")
+		}
 	}
 
 	return nil

--- a/templates/data-sources/azure_archival_location.md.tmpl
+++ b/templates/data-sources/azure_archival_location.md.tmpl
@@ -30,7 +30,7 @@ description: |-
 - `customer_managed_key` (Set of Object) Customer managed storage encryption. For `SPECIFIC_REGION`, a customer managed key for the specified region will be returned. For `SOURCE_REGION`, a customer managed key for each specified region will be returned, for other regions, data will be encrypted using platform managed keys. (see [below for nested schema](#nestedatt--customer_managed_key))
 - `location_template` (String) RSC location template. If a storage account region was specified, it will be `SPECIFIC_REGION`, otherwise `SOURCE_REGION`.
 - `redundancy` (String) Azure storage redundancy. Possible values are `GRS`, `GZRS`, `LRS`, `RA_GRS`, `RA_GZRS` and `ZRS`. Default value is `LRS`.
-- `storage_account_name_prefix` (String) Azure storage account name prefix. The storage account name prefix cannot be longer than 14 characters and can only consist of numbers and lower case letters.
+- `storage_account_name_prefix` (String) Azure storage account name prefix. For `SOURCE_REGION`, the prefix cannot be longer than 16 characters. For `SPECIFIC_REGION`, the name cannot be longer than 24 characters. The value can only consist of numbers and lower case letters.
 - `storage_account_region` (String) Azure region to store the snapshots in (`SPECIFIC_REGION`). If not specified, the snapshots will be stored in the same region as the workload (`SOURCE_REGION`).
 - `storage_account_tags` (Map of String) Azure storage account tags. Each tag will be added to the storage account created by RSC.
 - `storage_tier` (String) Azure storage tier. Possible values are `COOL` and `HOT`. Default value is `COOL`.


### PR DESCRIPTION
# Description

The limit was hardcoded to 14 characters but the backend accepts up to 16 for SOURCE_REGION (prefix + 8-char UID = 24, Azure's max) and up to 24 for SPECIFIC_REGION (name used directly). Add a CustomizeDiff to enforce the correct limit based on whether storage_account_region is set.

## Related Issue

Fixes #426 

## How Has This Been Tested?

Manually.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
