### PR TITLE
Add AWS role chaining support

### DIFF
--- a/docs/data-sources/aws_cnp_artifacts.md
+++ b/docs/data-sources/aws_cnp_artifacts.md
@@ -156,5 +156,5 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
 
 Required:
 
-- `name` (String) RSC feature name. Possible values are `CLOUD_DISCOVERY`, `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_PROTECTION`, `CLOUD_NATIVE_DYNAMODB_PROTECTION`, `CLOUD_NATIVE_S3_PROTECTION`, `KUBERNETES_PROTECTION`, `SERVERS_AND_APPS`, `EXOCOMPUTE` and `RDS_PROTECTION`.
-- `permission_groups` (Set of String) RSC permission groups for the feature. Possible values are `BASIC`, `CLOUD_CLUSTER_ES`, `RSC_MANAGED_CLUSTER`, `EXPORT_POWER_ON`, `EXPORT_POWER_OFF`, `RESTORE` and `DOWNLOAD_FILE`. For backwards compatibility, `[]` is interpreted as all applicable permission groups.
+- `name` (String) RSC feature name. Possible values are `CLOUD_DISCOVERY`, `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_DYNAMODB_PROTECTION`, `CLOUD_NATIVE_PROTECTION`, `CLOUD_NATIVE_S3_PROTECTION`, `EXOCOMPUTE`, `KUBERNETES_PROTECTION`, `RDS_PROTECTION`, `ROLE_CHAINING` and `SERVERS_AND_APPS`.
+- `permission_groups` (Set of String) RSC permission groups for the feature. Possible values are `BASIC`, `CLOUD_CLUSTER_ES`, `DOWNLOAD_FILE`, `EXPORT_POWER_ON`, `EXPORT_POWER_OFF`, `RESTORE` and `RSC_MANAGED_CLUSTER`. For backwards compatibility, `[]` is interpreted as all applicable permission groups.

--- a/docs/data-sources/aws_cnp_artifacts.md
+++ b/docs/data-sources/aws_cnp_artifacts.md
@@ -33,6 +33,9 @@ description: |-
   RDS_PROTECTION
   BASIC - Represents the basic set of permissions required to onboard the
   feature.
+  ROLE_CHAINING
+  BASIC - Represents the basic set of permissions required to onboard the
+  feature.
   SERVERS_AND_APPS
   CLOUD_CLUSTER_ES - Represents the basic set of permissions required to onboard the
   feature.
@@ -83,6 +86,10 @@ are used when specifying the feature set.
   * `BASIC` - Represents the basic set of permissions required to onboard the
     feature.
 
+`ROLE_CHAINING`
+  * `BASIC` - Represents the basic set of permissions required to onboard the
+    feature.
+
 `SERVERS_AND_APPS`
   * `CLOUD_CLUSTER_ES` - Represents the basic set of permissions required to onboard the
     feature.
@@ -93,7 +100,7 @@ are used when specifying the feature set.
 ## Example Usage
 
 ```terraform
-# Single feature with permission groups.
+# Single feature with one permission group.
 data "polaris_aws_cnp_artifacts" "artifacts" {
   feature {
     name = "CLOUD_NATIVE_PROTECTION"
@@ -103,8 +110,9 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
   }
 }
 
-# Single feature with multiple permission groups. When multiple permission
-# groups are specified, the BASIC permission group must always be included.
+# Single feature with multiple permission groups. BASIC must always be
+# included, except for the SERVERS_AND_APPS feature which only supports
+# the CLOUD_CLUSTER_ES permission group.
 data "polaris_aws_cnp_artifacts" "artifacts" {
   feature {
     name = "EXOCOMPUTE"
@@ -115,7 +123,7 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
   }
 }
 
-# Multiple features with permission groups.
+# Multiple features with multiple permission groups.
 data "polaris_aws_cnp_artifacts" "artifacts" {
   feature {
     name = "CLOUD_NATIVE_PROTECTION"
@@ -130,6 +138,24 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
       "BASIC",
       "RSC_MANAGED_CLUSTER",
     ]
+  }
+}
+
+# Using a variable for the features.
+variable "features" {
+  type = map(object({
+    permission_groups = set(string)
+  }))
+  description = "RSC features with permission groups."
+}
+
+data "polaris_aws_cnp_artifacts" "artifacts" {
+  dynamic "feature" {
+    for_each = var.features
+    content {
+      name              = feature.key
+      permission_groups = feature.value["permission_groups"]
+    }
   }
 }
 ```

--- a/docs/data-sources/aws_cnp_permissions.md
+++ b/docs/data-sources/aws_cnp_permissions.md
@@ -44,6 +44,10 @@ are used when specifying the feature set.
   * `BASIC` - Represents the basic set of permissions required to onboard the
     feature.
 
+`ROLE_CHAINING`
+  * `BASIC` - Represents the basic set of permissions required to onboard the
+    feature.
+
 `SERVERS_AND_APPS`
   * `CLOUD_CLUSTER_ES` - Represents the basic set of permissions required to onboard the
     feature.
@@ -97,6 +101,10 @@ are used when specifying the feature set.
   * `BASIC` - Represents the basic set of permissions required to onboard the
     feature.
 
+`ROLE_CHAINING`
+  * `BASIC` - Represents the basic set of permissions required to onboard the
+    feature.
+
 `SERVERS_AND_APPS`
   * `CLOUD_CLUSTER_ES` - Represents the basic set of permissions required to onboard the
     feature.
@@ -130,7 +138,6 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
 # polaris_aws_cnp_artifacts data source.
 data "polaris_aws_cnp_permissions" "permissions" {
   for_each = data.polaris_aws_cnp_artifacts.artifacts.role_keys
-  cloud    = data.polaris_aws_cnp_artifacts.artifacts.cloud
   role_key = each.key
 
   dynamic "feature" {

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -4,6 +4,15 @@ page_title: "Changelog"
 
 # Changelog
 
+## v1.6.3
+* New data source added for `polaris_feature_flag` which checks if a feature flag is enabled for the RSC account.
+  [[docs](../data-sources/feature_flag.md)]
+* Add support for the `ROLE_CHAINING` feature and `role_chaining_account_id` field in the `polaris_aws_cnp_account` and
+  `polaris_aws_cnp_account_attachments` resources, and in the `polaris_aws_cnp_permissions` data source.
+  [[docs](../resources/aws_cnp_account.md)] [[docs](../resources/aws_cnp_account_attachments.md)]
+* Fix `storage_account_name_prefix` max length validation in the `polaris_azure_archival_location` resource. The limit
+  is now 16 characters for `SOURCE_REGION` and 24 characters for `SPECIFIC_REGION`, matching the backend constraints.
+
 ## v1.6.2
 * Fix managed identity upgrade for the `sql_db_protection` block in the `polaris_azure_subscription` resource. The
   `upgradeFeatureToUseManagedIdentity` function was not including permission groups in the SDK call, causing the Go SDK

--- a/docs/guides/upgrade_guide_v1.6.3.md
+++ b/docs/guides/upgrade_guide_v1.6.3.md
@@ -1,0 +1,156 @@
+---
+page_title: "Upgrade Guide: v1.6.3"
+---
+
+# Upgrade Guide v1.6.3
+
+## Before Upgrading
+
+Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
+provider.
+
+## How to Upgrade
+
+Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.6.3 release. One
+way of doing this is by using the pessimistic constraint operator `~>`, which allows Terraform to upgrade to the latest
+release within the same minor version:
+```terraform
+terraform {
+  required_providers {
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "~> 1.6.0"
+    }
+  }
+}
+```
+Next, upgrade the provider to the new version by running:
+```shell
+% terraform init -upgrade
+```
+After the provider has been updated, validate the correctness of the Terraform configuration files by running:
+```shell
+% terraform plan
+```
+If you get an error or an unwanted diff, please see the _Significant Changes_ and _New Features_ sections below for
+additional instructions. Otherwise, proceed by running:
+```shell
+% terraform apply -refresh-only
+```
+This will read the remote state of the resources and migrate the local Terraform state to the v1.6.3 version.
+
+## New Features
+
+### polaris_feature_flag data source
+
+The new `polaris_feature_flag` data source checks if a feature flag is enabled for the RSC account.
+
+```terraform
+data "polaris_feature_flag" "my_feature_flag" {
+  name = "MY_FEATURE_FLAG"
+}
+
+output "my_feature_flag_enabled" {
+  value = data.polaris_feature_flag.my_feature_flag.enabled
+}
+```
+
+For more details, see the [polaris_feature_flag documentation](../data-sources/feature_flag.md).
+
+### polaris_aws_cnp_account: role chaining support
+
+The `polaris_aws_cnp_account` and `polaris_aws_cnp_account_attachments` resources now support the `ROLE_CHAINING`
+feature and the `role_chaining_account_id` field for cross-account role chaining. The `polaris_aws_cnp_artifacts` and
+the `polaris_aws_cnp_permissions` data sources have also been updated with role chaining support.
+
+To onboard the role-chaining AWS account, use the `ROLE_CHAINING` feature with the `BASIC` permission group:
+```terraform
+# Lookup the artifacts required for the role-chaining feature.
+data "polaris_aws_cnp_artifacts" "artifacts" {
+  feature {
+    name = "ROLE_CHAINING"
+    permission_groups = [
+      "BASIC",
+    ]
+  }
+}
+
+# Lookup the permissions required for each role artifact for the
+# role-chaining feature.
+data "polaris_aws_cnp_permissions" "permissions" {
+  for_each = data.polaris_aws_cnp_artifacts.artifacts.role_keys
+  role_key = each.key
+
+  feature {
+    name = "ROLE_CHAINING"
+    permission_groups = [
+      "BASIC",
+    ]
+  }
+}
+
+# Start onboarding the specified account as the role-chaining account.
+resource "polaris_aws_cnp_account" "account" {
+  name      = "Role-chaining Account"
+  native_id = "123456789123"
+
+  feature {
+    name = "ROLE_CHAINING"
+    permission_groups = [
+      "BASIC",
+    ]
+  }
+
+  regions = [
+    "us-east-2",
+  ]
+}
+
+# At this point the AWS Terraform provider should be used to create
+# the required role artifacts. The polaris_aws_cnp_artifacts and the
+# polaris_aws_cnp_permissions data sources together with the
+# trust_policies field from the polaris_aws_cnp_account resource is
+# used as input.
+
+# Attach the role artifacts to the role-chaining account.
+resource "polaris_aws_cnp_account_attachments" "attachments" {
+  account_id = polaris_aws_cnp_account.account.id
+
+  features = [
+    "ROLE_CHAINING"
+  ]
+  
+  dynamic "role" {
+    for_each = aws_iam_role.role
+    content {
+      key         = role.key
+      arn         = role.value["arn"]
+      permissions = data.polaris_aws_cnp_permissions.permissions[role.key].id
+    }
+  }
+}
+```
+Note that the `ROLE_CHAINING` feature is mutually exclusive with all other RSC features.
+
+To onboard a role-chained AWS account, i.e. an AWS account using the role-chaining AWS account, proceed as you normally
+would when you onboard an AWS account, but pass the role-chaining RSC cloud account ID (UUID) to the
+`polaris_aws_cnp_account` and the `polaris_aws_cnp_account_attachments` resources using the `role_chaining_account_id`
+field.
+
+For a complete example of how to onboard an AWS account to RSC, look at the
+[AWS IAM account](https://github.com/rubrikinc/terraform-provider-polaris-examples/tree/main/modules/aws_iam_account)
+module in the [examples](https://github.com/rubrikinc/terraform-provider-polaris-examples/tree/main) repository. 
+
+Note that the `polaris_aws_cnp_account_trust_policy` resource does not support role chaining. Use the `trust_policies`
+field of the `polaris_aws_cnp_account` resource when using role chaining.
+
+For more details, see the [polaris_aws_cnp_account documentation](../resources/aws_cnp_account.md) and the
+[polaris_aws_cnp_account_attachments documentation](../resources/aws_cnp_account_attachments.md).
+
+## Bug Fixes
+
+### polaris_azure_archival_location: storage_account_name_prefix max length fix
+
+The `storage_account_name_prefix` field was hardcoded to a maximum of 14 characters, but the backend accepts up to 16
+for `SOURCE_REGION` (prefix + 8-character UID = 24, Azure's max) and up to 24 for `SPECIFIC_REGION` (name used
+directly). The provider now enforces the correct limit based on whether `storage_account_region` is set.

--- a/docs/resources/aws_cnp_account.md
+++ b/docs/resources/aws_cnp_account.md
@@ -212,6 +212,7 @@ resource "polaris_aws_cnp_account" "account" {
 - `delete_snapshots_on_destroy` (Boolean) Should snapshots be deleted when the resource is destroyed.
 - `external_id` (String) External ID. Changing this forces a new resource to be created.
 - `name` (String) Account name.
+- `role_chaining_account_id` (String) RSC cloud account ID of the role chaining account. When specified, the account will use cross-account role chaining. Changing this forces a new resource to be created.
 
 ### Read-Only
 

--- a/docs/resources/aws_cnp_account.md
+++ b/docs/resources/aws_cnp_account.md
@@ -44,11 +44,15 @@ are used when specifying the feature set.
   * `RSC_MANAGED_CLUSTER` - Represents the set of permissions required for the
     Rubrik-managed Exocompute cluster.
 
+`KUBERNETES_PROTECTION`
+  * `BASIC` - Represents the basic set of permissions required to onboard the
+    feature.
+
 `RDS_PROTECTION`
   * `BASIC` - Represents the basic set of permissions required to onboard the
     feature.
 
-`KUBERNETES_PROTECTION`
+`ROLE_CHAINING`
   * `BASIC` - Represents the basic set of permissions required to onboard the
     feature.
 
@@ -108,11 +112,15 @@ are used when specifying the feature set.
   * `RSC_MANAGED_CLUSTER` - Represents the set of permissions required for the
     Rubrik-managed Exocompute cluster.
 
+`KUBERNETES_PROTECTION`
+  * `BASIC` - Represents the basic set of permissions required to onboard the
+    feature.
+
 `RDS_PROTECTION`
   * `BASIC` - Represents the basic set of permissions required to onboard the
     feature.
 
-`KUBERNETES_PROTECTION`
+`ROLE_CHAINING`
   * `BASIC` - Represents the basic set of permissions required to onboard the
     feature.
 
@@ -131,15 +139,10 @@ are used when specifying the feature set.
 ## Example Usage
 
 ```terraform
-# Using hardcoded values.
+# Basic example.
 resource "polaris_aws_cnp_account" "account" {
   name      = "My Account"
   native_id = "123456789123"
-
-  regions = [
-    "us-east-2",
-    "us-west-2",
-  ]
 
   feature {
     name = "CLOUD_NATIVE_PROTECTION"
@@ -155,6 +158,54 @@ resource "polaris_aws_cnp_account" "account" {
       "RSC_MANAGED_CLUSTER",
     ]
   }
+
+  regions = [
+    "us-east-2",
+  ]
+}
+
+# Role-chaining account, can be used by one or more role-chained accounts.
+resource "polaris_aws_cnp_account" "role_chaining" {
+  name      = "Role-chaining Account"
+  native_id = "123456789123"
+
+  feature {
+    name = "ROLE_CHAINING"
+    permission_groups = [
+      "BASIC",
+    ]
+  }
+
+  regions = [
+    "us-east-2",
+  ]
+}
+
+# Role-chained account, using a previously onboarded role-chaining account.
+resource "polaris_aws_cnp_account" "role_chained" {
+  name                     = "Role-Chained Account"
+  native_id                = "234567891234"
+  role_chaining_account_id = polaris_aws_cnp_account.role_chaining.id
+
+  feature {
+    name = "CLOUD_NATIVE_PROTECTION"
+    permission_groups = [
+      "BASIC",
+    ]
+  }
+
+  feature {
+    name = "EXOCOMPUTE"
+    permission_groups = [
+      "BASIC",
+      "RSC_MANAGED_CLUSTER",
+    ]
+  }
+
+  regions = [
+    "us-east-2",
+    "us-west-2",
+  ]
 }
 
 # Using variables for the account values and the features. The dynamic

--- a/docs/resources/aws_cnp_account_attachments.md
+++ b/docs/resources/aws_cnp_account_attachments.md
@@ -52,12 +52,13 @@ resource "polaris_aws_cnp_account_attachments" "attachments" {
 ### Required
 
 - `account_id` (String) RSC cloud account ID (UUID). Changing this forces a new resource to be created.
-- `features` (Set of String) RSC features. Possible values are `CLOUD_DISCOVERY`, `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_DYNAMODB_PROTECTION`, `CLOUD_NATIVE_PROTECTION`, `CLOUD_NATIVE_S3_PROTECTION`, `KUBERNETES_PROTECTION`, `SERVERS_AND_APPS`, `EXOCOMPUTE` and `RDS_PROTECTION`.
+- `features` (Set of String) RSC features. Possible values are `CLOUD_DISCOVERY`, `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_DYNAMODB_PROTECTION`, `CLOUD_NATIVE_PROTECTION`, `CLOUD_NATIVE_S3_PROTECTION`, `EXOCOMPUTE`, `KUBERNETES_PROTECTION`, `RDS_PROTECTION`, `ROLE_CHAINING` and `SERVERS_AND_APPS`.
 - `role` (Block Set, Min: 1) Roles to attach to the cloud account. (see [below for nested schema](#nestedblock--role))
 
 ### Optional
 
 - `instance_profile` (Block Set) Instance profiles to attach to the cloud account. (see [below for nested schema](#nestedblock--instance_profile))
+- `role_chaining_account_id` (String) RSC cloud account ID of the role chaining account. When specified, the account will use cross-account role chaining.
 
 ### Read-Only
 

--- a/docs/resources/aws_cnp_account_attachments.md
+++ b/docs/resources/aws_cnp_account_attachments.md
@@ -20,12 +20,39 @@ roles to an RSC cloud account.
 ## Example Usage
 
 ```terraform
-# The configuration assumes that an AWS account has been been added
-# to RSC and that one AWS IAM instance profile and role has been
-# created for each RSC artifact.
+# Attach artifacts to an account. Artifacts are IAM roles and instance
+# profiles. The artifacts required can be looked up using the
+# polaris_aws_cnp_artifacts and polaris_aws_cnp_permissions data
+# sources. The configuration assumes that one AWS IAM instance profile
+# and role has been defined for each RSC artifact.
 resource "polaris_aws_cnp_account_attachments" "attachments" {
   account_id = polaris_aws_cnp_account.account.id
   features   = polaris_aws_cnp_account.account.feature.*.name
+
+  dynamic "instance_profile" {
+    for_each = aws_iam_instance_profile.profile
+    content {
+      key  = instance_profile.key
+      name = instance_profile.value["arn"]
+    }
+  }
+
+  dynamic "role" {
+    for_each = aws_iam_role.role
+    content {
+      key         = role.key
+      arn         = role.value["arn"]
+      permissions = data.polaris_aws_cnp_permissions.permissions[role.key].id
+    }
+  }
+}
+
+# Attach artifacts to a role-chained account. To attach artifacts to
+# the role-chaining account, use the above example.
+resource "polaris_aws_cnp_account_attachments" "attachments" {
+  account_id               = polaris_aws_cnp_account.account.id
+  features                 = polaris_aws_cnp_account.account.feature.*.name
+  role_chaining_account_id = polaris_aws_cnp_account.role_chaining.id
 
   dynamic "instance_profile" {
     for_each = aws_iam_instance_profile.profile

--- a/docs/resources/aws_cnp_account_trust_policy.md
+++ b/docs/resources/aws_cnp_account_trust_policy.md
@@ -8,8 +8,11 @@ required by RSC. The `policy` field of `aws_cnp_account_trust_policy` resource
 should be used with the `assume_role_policy` of the `aws_iam_role` resource.
 
 ~> **Note:** The `polaris_aws_cnp_account` resource can now be used to get the
-   IAM trust policies for all role keys. The `aws_cnp_account_trust_policy`
+   IAM trust policies for all role keys. The `polaris_aws_cnp_account_trust_policy`
    resource is no longer required and will be deprecated in a future version.
+
+~> **Note:** This resource does not support role chaining. Use the `trust_policies`
+   field of the `polaris_aws_cnp_account` resource for accounts using role chaining.
 
 ~> **Note:** Once `external_id` has been set it cannot be changed. Unless the
    cloud account is removed and onboarded again.
@@ -27,8 +30,11 @@ required by RSC. The `policy` field of `aws_cnp_account_trust_policy` resource
 should be used with the `assume_role_policy` of the `aws_iam_role` resource.
 
 ~> **Note:** The `polaris_aws_cnp_account` resource can now be used to get the
-   IAM trust policies for all role keys. The `aws_cnp_account_trust_policy`
+   IAM trust policies for all role keys. The `polaris_aws_cnp_account_trust_policy`
    resource is no longer required and will be deprecated in a future version.
+
+~> **Note:** This resource does not support role chaining. Use the `trust_policies`
+   field of the `polaris_aws_cnp_account` resource for accounts using role chaining.
 
 ~> **Note:** Once `external_id` has been set it cannot be changed. Unless the
    cloud account is removed and onboarded again.

--- a/docs/resources/aws_cnp_account_trust_policy.md
+++ b/docs/resources/aws_cnp_account_trust_policy.md
@@ -50,7 +50,6 @@ should be used with the `assume_role_policy` of the `aws_iam_role` resource.
 data "polaris_aws_cnp_artifacts" "artifacts" {
   feature {
     name = "CLOUD_NATIVE_ARCHIVAL"
-
     permission_groups = [
       "BASIC",
     ]
@@ -58,7 +57,6 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
 
   feature {
     name = "CLOUD_NATIVE_PROTECTION"
-
     permission_groups = [
       "BASIC",
       "EXPORT_AND_RESTORE",
@@ -69,10 +67,6 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
 resource "polaris_aws_cnp_account" "account" {
   name      = "My Account"
   native_id = "123456789123"
-  regions = [
-    "us-east-2",
-    "us-west-2",
-  ]
 
   dynamic "feature" {
     for_each = data.polaris_aws_cnp_artifacts.artifacts.feature
@@ -81,6 +75,10 @@ resource "polaris_aws_cnp_account" "account" {
       permission_groups = feature.value["permission_groups"]
     }
   }
+
+  regions = [
+    "us-east-2",
+  ]
 }
 
 # Lookup the trust policies using the artifacts data source and the

--- a/examples/data-sources/polaris_aws_cnp_artifacts/data-source.tf
+++ b/examples/data-sources/polaris_aws_cnp_artifacts/data-source.tf
@@ -1,4 +1,4 @@
-# Single feature with permission groups.
+# Single feature with one permission group.
 data "polaris_aws_cnp_artifacts" "artifacts" {
   feature {
     name = "CLOUD_NATIVE_PROTECTION"
@@ -8,8 +8,9 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
   }
 }
 
-# Single feature with multiple permission groups. When multiple permission
-# groups are specified, the BASIC permission group must always be included.
+# Single feature with multiple permission groups. BASIC must always be
+# included, except for the SERVERS_AND_APPS feature which only supports
+# the CLOUD_CLUSTER_ES permission group.
 data "polaris_aws_cnp_artifacts" "artifacts" {
   feature {
     name = "EXOCOMPUTE"
@@ -20,7 +21,7 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
   }
 }
 
-# Multiple features with permission groups.
+# Multiple features with multiple permission groups.
 data "polaris_aws_cnp_artifacts" "artifacts" {
   feature {
     name = "CLOUD_NATIVE_PROTECTION"
@@ -35,5 +36,23 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
       "BASIC",
       "RSC_MANAGED_CLUSTER",
     ]
+  }
+}
+
+# Using a variable for the features.
+variable "features" {
+  type = map(object({
+    permission_groups = set(string)
+  }))
+  description = "RSC features with permission groups."
+}
+
+data "polaris_aws_cnp_artifacts" "artifacts" {
+  dynamic "feature" {
+    for_each = var.features
+    content {
+      name              = feature.key
+      permission_groups = feature.value["permission_groups"]
+    }
   }
 }

--- a/examples/data-sources/polaris_aws_cnp_permissions/data-source.tf
+++ b/examples/data-sources/polaris_aws_cnp_permissions/data-source.tf
@@ -19,7 +19,6 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
 # polaris_aws_cnp_artifacts data source.
 data "polaris_aws_cnp_permissions" "permissions" {
   for_each = data.polaris_aws_cnp_artifacts.artifacts.role_keys
-  cloud    = data.polaris_aws_cnp_artifacts.artifacts.cloud
   role_key = each.key
 
   dynamic "feature" {

--- a/examples/resources/polaris_aws_cnp_account/resource.tf
+++ b/examples/resources/polaris_aws_cnp_account/resource.tf
@@ -1,12 +1,7 @@
-# Using hardcoded values.
+# Basic example.
 resource "polaris_aws_cnp_account" "account" {
   name      = "My Account"
   native_id = "123456789123"
-
-  regions = [
-    "us-east-2",
-    "us-west-2",
-  ]
 
   feature {
     name = "CLOUD_NATIVE_PROTECTION"
@@ -22,6 +17,54 @@ resource "polaris_aws_cnp_account" "account" {
       "RSC_MANAGED_CLUSTER",
     ]
   }
+
+  regions = [
+    "us-east-2",
+  ]
+}
+
+# Role-chaining account, can be used by one or more role-chained accounts.
+resource "polaris_aws_cnp_account" "role_chaining" {
+  name      = "Role-chaining Account"
+  native_id = "123456789123"
+
+  feature {
+    name = "ROLE_CHAINING"
+    permission_groups = [
+      "BASIC",
+    ]
+  }
+
+  regions = [
+    "us-east-2",
+  ]
+}
+
+# Role-chained account, using a previously onboarded role-chaining account.
+resource "polaris_aws_cnp_account" "role_chained" {
+  name                     = "Role-Chained Account"
+  native_id                = "234567891234"
+  role_chaining_account_id = polaris_aws_cnp_account.role_chaining.id
+
+  feature {
+    name = "CLOUD_NATIVE_PROTECTION"
+    permission_groups = [
+      "BASIC",
+    ]
+  }
+
+  feature {
+    name = "EXOCOMPUTE"
+    permission_groups = [
+      "BASIC",
+      "RSC_MANAGED_CLUSTER",
+    ]
+  }
+
+  regions = [
+    "us-east-2",
+    "us-west-2",
+  ]
 }
 
 # Using variables for the account values and the features. The dynamic

--- a/examples/resources/polaris_aws_cnp_account_attachments/resource.tf
+++ b/examples/resources/polaris_aws_cnp_account_attachments/resource.tf
@@ -1,9 +1,36 @@
-# The configuration assumes that an AWS account has been been added
-# to RSC and that one AWS IAM instance profile and role has been
-# created for each RSC artifact.
+# Attach artifacts to an account. Artifacts are IAM roles and instance
+# profiles. The artifacts required can be looked up using the
+# polaris_aws_cnp_artifacts and polaris_aws_cnp_permissions data
+# sources. The configuration assumes that one AWS IAM instance profile
+# and role has been defined for each RSC artifact.
 resource "polaris_aws_cnp_account_attachments" "attachments" {
   account_id = polaris_aws_cnp_account.account.id
   features   = polaris_aws_cnp_account.account.feature.*.name
+
+  dynamic "instance_profile" {
+    for_each = aws_iam_instance_profile.profile
+    content {
+      key  = instance_profile.key
+      name = instance_profile.value["arn"]
+    }
+  }
+
+  dynamic "role" {
+    for_each = aws_iam_role.role
+    content {
+      key         = role.key
+      arn         = role.value["arn"]
+      permissions = data.polaris_aws_cnp_permissions.permissions[role.key].id
+    }
+  }
+}
+
+# Attach artifacts to a role-chained account. To attach artifacts to
+# the role-chaining account, use the above example.
+resource "polaris_aws_cnp_account_attachments" "attachments" {
+  account_id               = polaris_aws_cnp_account.account.id
+  features                 = polaris_aws_cnp_account.account.feature.*.name
+  role_chaining_account_id = polaris_aws_cnp_account.role_chaining.id
 
   dynamic "instance_profile" {
     for_each = aws_iam_instance_profile.profile

--- a/examples/resources/polaris_aws_cnp_account_trust_policy/resource.tf
+++ b/examples/resources/polaris_aws_cnp_account_trust_policy/resource.tf
@@ -1,7 +1,6 @@
 data "polaris_aws_cnp_artifacts" "artifacts" {
   feature {
     name = "CLOUD_NATIVE_ARCHIVAL"
-
     permission_groups = [
       "BASIC",
     ]
@@ -9,7 +8,6 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
 
   feature {
     name = "CLOUD_NATIVE_PROTECTION"
-
     permission_groups = [
       "BASIC",
       "EXPORT_AND_RESTORE",
@@ -20,10 +18,6 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
 resource "polaris_aws_cnp_account" "account" {
   name      = "My Account"
   native_id = "123456789123"
-  regions = [
-    "us-east-2",
-    "us-west-2",
-  ]
 
   dynamic "feature" {
     for_each = data.polaris_aws_cnp_artifacts.artifacts.feature
@@ -32,6 +26,10 @@ resource "polaris_aws_cnp_account" "account" {
       permission_groups = feature.value["permission_groups"]
     }
   }
+
+  regions = [
+    "us-east-2",
+  ]
 }
 
 # Lookup the trust policies using the artifacts data source and the

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.22.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.2-0.20260414113603-c4e776d70f91
+	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.2-0.20260414194954-4055ea0a087b
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.22.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.1
+	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.2-0.20260414113603-c4e776d70f91
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.1 h1:hMdvkiPZfae0DLwl7wTlErAmHJBNqUSV2LvOmHzu0dE=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.1/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.2-0.20260414113603-c4e776d70f91 h1:7+gh99QxOXZvlXgJQjXJj0yyEveqFGe56XKnIO/wYG8=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.2-0.20260414113603-c4e776d70f91/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.2-0.20260414113603-c4e776d70f91 h1:7+gh99QxOXZvlXgJQjXJj0yyEveqFGe56XKnIO/wYG8=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.2-0.20260414113603-c4e776d70f91/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.2-0.20260414194954-4055ea0a087b h1:4gypsdgrLKmAKPQAtjFur2g7DQhaQ9p0NXaZKJ4l900=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.4.2-0.20260414194954-4055ea0a087b/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/internal/provider/data_source_aws_cnp_artifacts.go
+++ b/internal/provider/data_source_aws_cnp_artifacts.go
@@ -146,6 +146,9 @@ func awsArtifactsRead(ctx context.Context, d *schema.ResourceData, m interface{}
 
 		features = append(features, feature)
 	}
+	if err := core.ValidateRoleChaining(features); err != nil {
+		return diag.FromErr(err)
+	}
 
 	// Request artifacts.
 	profiles, roles, err := aws.Wrap(client).Artifacts(ctx, cloud, features)

--- a/internal/provider/data_source_aws_cnp_artifacts.go
+++ b/internal/provider/data_source_aws_cnp_artifacts.go
@@ -75,6 +75,10 @@ are used when specifying the feature set.
   * ´BASIC´ - Represents the basic set of permissions required to onboard the
     feature.
 
+´ROLE_CHAINING´
+  * ´BASIC´ - Represents the basic set of permissions required to onboard the
+    feature.
+
 ´SERVERS_AND_APPS´
   * ´CLOUD_CLUSTER_ES´ - Represents the basic set of permissions required to onboard the
     feature.

--- a/internal/provider/data_source_aws_cnp_permissions.go
+++ b/internal/provider/data_source_aws_cnp_permissions.go
@@ -77,6 +77,10 @@ are used when specifying the feature set.
   * ´BASIC´ - Represents the basic set of permissions required to onboard the
     feature.
 
+´ROLE_CHAINING´
+  * ´BASIC´ - Represents the basic set of permissions required to onboard the
+    feature.
+
 ´SERVERS_AND_APPS´
   * ´CLOUD_CLUSTER_ES´ - Represents the basic set of permissions required to onboard the
     feature.

--- a/internal/provider/data_source_aws_cnp_permissions.go
+++ b/internal/provider/data_source_aws_cnp_permissions.go
@@ -85,6 +85,24 @@ are used when specifying the feature set.
    is always required except for the ´SERVERS_AND_APPS´ feature.
 `
 
+// roleChainingSyntheticPolicy is the policy document injected when the RSC
+// backend does not return any policy data for the ROLE_CHAINING feature.
+const roleChainingSyntheticPolicy = `{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "RoleChainingPolicySid",
+            "Effect": "Allow",
+            "Action": [
+                "sts:AssumeRole"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}`
+
 // This data source uses a template for its documentation due to a bug in the TF
 // docs generator. Remember to update the template if the documentation for any
 // fields are changed.
@@ -180,11 +198,27 @@ func awsPermissionsRead(ctx context.Context, d *schema.ResourceData, m interface
 		features = append(features, feature)
 	}
 	roleKey := d.Get(keyRoleKey).(string)
+	if err := core.ValidateRoleChaining(features); err != nil {
+		return diag.FromErr(err)
+	}
 
 	customerPolicies, managedPolicies, err := aws.Wrap(client).Permissions(ctx, cloud, features, ec2RecoveryRolePath)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Workaround: the RSC backend does not return any policy data for
+	// the ROLE_CHAINING feature. Inject the expected sts:AssumeRole
+	// policy until the backend is fixed.
+	if len(features) == 1 && features[0].Equal(core.FeatureRoleChaining) && roleKey == "CROSSACCOUNT" && len(customerPolicies) == 0 {
+		customerPolicies = []aws.CustomerManagedPolicy{{
+			Artifact: roleKey,
+			Feature:  core.FeatureRoleChaining,
+			Name:     "RoleChaining",
+			Policy:   roleChainingSyntheticPolicy,
+		}}
+	}
+
 	slices.SortFunc(customerPolicies, func(i, j aws.CustomerManagedPolicy) int {
 		if r := cmp.Compare(i.Artifact, j.Artifact); r != 0 {
 			return r

--- a/internal/provider/data_source_aws_cnp_permissions.go
+++ b/internal/provider/data_source_aws_cnp_permissions.go
@@ -241,6 +241,7 @@ func awsPermissionsRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	var customerPoliciesAttr []map[string]string
 	for _, policy := range customerPolicies {
+		// endorctl:allow
 		if roleKey == policy.Artifact {
 			customerPoliciesAttr = append(customerPoliciesAttr, map[string]string{
 				keyFeature: policy.Feature.Name,
@@ -259,6 +260,7 @@ func awsPermissionsRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	var managedPoliciesAttr []string
 	for _, policy := range managedPolicies {
+		// endorctl:allow
 		if roleKey == policy.Artifact {
 			managedPoliciesAttr = append(managedPoliciesAttr, policy.Name)
 			hash.Write([]byte(policy.Artifact))

--- a/internal/provider/resource_aws_cnp_account.go
+++ b/internal/provider/resource_aws_cnp_account.go
@@ -625,7 +625,7 @@ func trustPolicyResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "RSC artifact key for the AWS role. Possible values are `CROSSACCOUNT`, " +
-					"`EXOCOMPUTE_EKS_MASTERNODE` and `EXOCOMPUTE_EKS_WORKERNODE`.",
+					"`EXOCOMPUTE_EKS_MASTERNODE`, `EXOCOMPUTE_EKS_WORKERNODE` and `EXOCOMPUTE_EKS_LAMBDA`.",
 			},
 			keyPolicy: {
 				Type:        schema.TypeString,

--- a/internal/provider/resource_aws_cnp_account.go
+++ b/internal/provider/resource_aws_cnp_account.go
@@ -80,11 +80,15 @@ are used when specifying the feature set.
   * ´RSC_MANAGED_CLUSTER´ - Represents the set of permissions required for the
     Rubrik-managed Exocompute cluster.
 
+´KUBERNETES_PROTECTION´
+  * ´BASIC´ - Represents the basic set of permissions required to onboard the
+    feature.
+
 ´RDS_PROTECTION´
   * ´BASIC´ - Represents the basic set of permissions required to onboard the
     feature.
 
-´KUBERNETES_PROTECTION´
+´ROLE_CHAINING´
   * ´BASIC´ - Represents the basic set of permissions required to onboard the
     feature.
 

--- a/internal/provider/resource_aws_cnp_account.go
+++ b/internal/provider/resource_aws_cnp_account.go
@@ -228,7 +228,13 @@ func awsCreateCnpAccount(ctx context.Context, d *schema.ResourceData, m any) dia
 		return diag.FromErr(err)
 	}
 
-	if _, err := aws.Wrap(client).TrustPolicies(ctx, gqlaws.Cloud(cloud), id, features, externalID, roleChainingAccountID); err != nil {
+	if _, err := aws.Wrap(client).TrustPolicies(ctx, aws.TrustPoliciesParams{
+		Cloud:                 gqlaws.Cloud(cloud),
+		CloudAccountID:        id,
+		Features:              features,
+		ExternalID:            externalID,
+		RoleChainingAccountID: roleChainingAccountID,
+	}); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -273,7 +279,13 @@ func awsReadCnpAccount(ctx context.Context, d *schema.ResourceData, m any) diag.
 			}
 		}
 	}
-	policies, err := aws.Wrap(client).TrustPolicies(ctx, gqlaws.Cloud(account.Cloud), id, features, externalID, roleChainingAccountID)
+	policies, err := aws.Wrap(client).TrustPolicies(ctx, aws.TrustPoliciesParams{
+		Cloud:                 gqlaws.Cloud(account.Cloud),
+		CloudAccountID:        id,
+		Features:              features,
+		ExternalID:            externalID,
+		RoleChainingAccountID: roleChainingAccountID,
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_aws_cnp_account.go
+++ b/internal/provider/resource_aws_cnp_account.go
@@ -156,6 +156,14 @@ func resourceAwsCnpAccount() *schema.Resource {
 				Description:  "AWS account ID. Changing this forces a new resource to be created.",
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
+			keyRoleChainingAccountID: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+				Description: "RSC cloud account ID of the role chaining account. When specified, " +
+					"the account will use cross-account role chaining.",
+			},
 			keyRegions: {
 				Type: schema.TypeSet,
 				Elem: &schema.Schema{
@@ -207,12 +215,20 @@ func awsCreateCnpAccount(ctx context.Context, d *schema.ResourceData, m any) dia
 		regions = append(regions, region.(string))
 	}
 
+	var roleChainingAccountID uuid.UUID
+	if id, ok := d.GetOk(keyRoleChainingAccountID); ok {
+		roleChainingAccountID, err = uuid.Parse(id.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+
 	id, err := aws.Wrap(client).AddAccountWithIAM(ctx, aws.AccountWithName(cloud, nativeID, name), features, aws.Regions(regions...))
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	if _, err := aws.Wrap(client).TrustPolicies(ctx, gqlaws.Cloud(cloud), id, features, externalID); err != nil {
+	if _, err := aws.Wrap(client).TrustPolicies(ctx, gqlaws.Cloud(cloud), id, features, externalID, roleChainingAccountID); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -248,7 +264,16 @@ func awsReadCnpAccount(ctx context.Context, d *schema.ResourceData, m any) diag.
 	for _, feature := range account.Features {
 		features = append(features, feature.Feature)
 	}
-	policies, err := aws.Wrap(client).TrustPolicies(ctx, gqlaws.Cloud(account.Cloud), id, features, externalID)
+	roleChainingAccountID := account.RoleChainingAccountID
+	if roleChainingAccountID == uuid.Nil {
+		if id, ok := d.GetOk(keyRoleChainingAccountID); ok {
+			roleChainingAccountID, err = uuid.Parse(id.(string))
+			if err != nil {
+				return diag.FromErr(err)
+			}
+		}
+	}
+	policies, err := aws.Wrap(client).TrustPolicies(ctx, gqlaws.Cloud(account.Cloud), id, features, externalID, roleChainingAccountID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -284,6 +309,11 @@ func awsReadCnpAccount(ctx context.Context, d *schema.ResourceData, m any) diag.
 	}
 	if err := d.Set(keyRegions, regions); err != nil {
 		return diag.FromErr(err)
+	}
+	if account.RoleChainingAccountID != uuid.Nil {
+		if err := d.Set(keyRoleChainingAccountID, account.RoleChainingAccountID.String()); err != nil {
+			return diag.FromErr(err)
+		}
 	}
 	policySet := &schema.Set{F: schema.HashResource(trustPolicyResource())}
 	for roleKey, policy := range policies {
@@ -422,6 +452,15 @@ func awsDeleteCnpAccount(ctx context.Context, d *schema.ResourceData, m any) dia
 func awsCustomizeDiffCnpAccount(ctx context.Context, diff *schema.ResourceDiff, m any) error {
 	tflog.Trace(ctx, "awsCustomizeDiffCnpAccount")
 
+	// Prevent ROLE_CHAINING from being combined with other features.
+	var features []core.Feature
+	for _, block := range diff.Get(keyFeature).(*schema.Set).List() {
+		features = append(features, core.Feature{Name: block.(map[string]any)[keyName].(string)})
+	}
+	if err := core.ValidateRoleChaining(features); err != nil {
+		return err
+	}
+
 	if diff.HasChange(keyFeature) {
 		if err := diff.SetNewComputed(keyTrustPolicies); err != nil {
 			return err
@@ -506,12 +545,12 @@ func featureResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				Description: "RSC feature name. Possible values are `CLOUD_DISCOVERY`, `CLOUD_NATIVE_ARCHIVAL`, " +
-					"`CLOUD_NATIVE_PROTECTION`, `CLOUD_NATIVE_DYNAMODB_PROTECTION`, `CLOUD_NATIVE_S3_PROTECTION`, " +
-					"`KUBERNETES_PROTECTION`, `SERVERS_AND_APPS`, `EXOCOMPUTE` and `RDS_PROTECTION`.",
+					"`CLOUD_NATIVE_DYNAMODB_PROTECTION`, `CLOUD_NATIVE_PROTECTION`, `CLOUD_NATIVE_S3_PROTECTION`, " +
+					"`EXOCOMPUTE`, `KUBERNETES_PROTECTION`, `RDS_PROTECTION`, `ROLE_CHAINING` and `SERVERS_AND_APPS`.",
 				ValidateFunc: validation.StringInSlice([]string{
 					"CLOUD_DISCOVERY", "CLOUD_NATIVE_ARCHIVAL", "CLOUD_NATIVE_PROTECTION",
 					"CLOUD_NATIVE_DYNAMODB_PROTECTION", "CLOUD_NATIVE_S3_PROTECTION", "KUBERNETES_PROTECTION",
-					"EXOCOMPUTE", "RDS_PROTECTION", "SERVERS_AND_APPS",
+					"EXOCOMPUTE", "ROLE_CHAINING", "RDS_PROTECTION", "SERVERS_AND_APPS",
 				}, false),
 			},
 			keyPermissionGroups: {
@@ -528,8 +567,8 @@ func featureResource() *schema.Resource {
 				},
 				Required: true,
 				Description: "RSC permission groups for the feature. Possible values are `BASIC`, " +
-					"`CLOUD_CLUSTER_ES`, `RSC_MANAGED_CLUSTER`, `EXPORT_POWER_ON`, `EXPORT_POWER_OFF`, " +
-					"`RESTORE` and `DOWNLOAD_FILE`. For backwards compatibility, `[]` is " +
+					"`CLOUD_CLUSTER_ES`, `DOWNLOAD_FILE`, `EXPORT_POWER_ON`, `EXPORT_POWER_OFF`, " +
+					"`RESTORE` and `RSC_MANAGED_CLUSTER`. For backwards compatibility, `[]` is " +
 					"interpreted as all applicable permission groups.",
 			},
 		},

--- a/internal/provider/resource_aws_cnp_account_attachments.go
+++ b/internal/provider/resource_aws_cnp_account_attachments.go
@@ -144,7 +144,13 @@ func awsCreateCnpAccountAttachments(ctx context.Context, d *schema.ResourceData,
 			return diag.FromErr(err)
 		}
 	}
-	id, err := aws.Wrap(client).AddAccountArtifacts(ctx, accountID, features, profiles, roles, roleChainingAccountID)
+	id, err := aws.Wrap(client).AddAccountArtifacts(ctx, aws.AddAccountArtifactsParams{
+		CloudAccountID:        accountID,
+		Features:              features,
+		InstanceProfiles:      profiles,
+		Roles:                 roles,
+		RoleChainingAccountID: roleChainingAccountID,
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -262,7 +268,13 @@ func awsUpdateCnpAccountAttachments(ctx context.Context, d *schema.ResourceData,
 			return diag.FromErr(err)
 		}
 	}
-	_, err = aws.Wrap(client).AddAccountArtifacts(ctx, id, features, profiles, roles, roleChainingAccountID)
+	_, err = aws.Wrap(client).AddAccountArtifacts(ctx, aws.AddAccountArtifactsParams{
+		CloudAccountID:        id,
+		Features:              features,
+		InstanceProfiles:      profiles,
+		Roles:                 roles,
+		RoleChainingAccountID: roleChainingAccountID,
+	})
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_aws_cnp_account_attachments.go
+++ b/internal/provider/resource_aws_cnp_account_attachments.go
@@ -70,20 +70,28 @@ func resourceAwsCnpAccountAttachments() *schema.Resource {
 					ValidateFunc: validation.StringInSlice([]string{
 						"CLOUD_DISCOVERY", "CLOUD_NATIVE_ARCHIVAL", "CLOUD_NATIVE_PROTECTION",
 						"CLOUD_NATIVE_S3_PROTECTION", "CLOUD_NATIVE_DYNAMODB_PROTECTION", "EXOCOMPUTE",
-						"RDS_PROTECTION", "KUBERNETES_PROTECTION", "SERVERS_AND_APPS",
+						"RDS_PROTECTION", "KUBERNETES_PROTECTION", "SERVERS_AND_APPS", "ROLE_CHAINING",
 					}, false),
 				},
 				MinItems: 1,
 				Required: true,
 				Description: "RSC features. Possible values are `CLOUD_DISCOVERY`, `CLOUD_NATIVE_ARCHIVAL`, " +
 					"`CLOUD_NATIVE_DYNAMODB_PROTECTION`, `CLOUD_NATIVE_PROTECTION`, `CLOUD_NATIVE_S3_PROTECTION`, " +
-					"`KUBERNETES_PROTECTION`, `SERVERS_AND_APPS`, `EXOCOMPUTE` and `RDS_PROTECTION`.",
+					"`EXOCOMPUTE`, `KUBERNETES_PROTECTION`, `RDS_PROTECTION`, `ROLE_CHAINING` and `SERVERS_AND_APPS`.",
 			},
 			keyInstanceProfile: {
 				Type:        schema.TypeSet,
 				Elem:        instanceProfileResource(),
 				Optional:    true,
 				Description: "Instance profiles to attach to the cloud account.",
+			},
+			keyRoleChainingAccountID: {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.IsUUID,
+				Description: "RSC cloud account ID of the role chaining account. When specified, " +
+					"the account will use cross-account role chaining.",
 			},
 			keyRole: {
 				Type:        schema.TypeSet,
@@ -92,6 +100,7 @@ func resourceAwsCnpAccountAttachments() *schema.Resource {
 				Description: "Roles to attach to the cloud account.",
 			},
 		},
+		CustomizeDiff: awsCustomizeDiffCnpAccountAttachments,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -125,8 +134,17 @@ func awsCreateCnpAccountAttachments(ctx context.Context, d *schema.ResourceData,
 		roles[block[keyKey].(string)] = block[keyARN].(string)
 	}
 
+	ensureRoleChainingArtifact(roles, features)
+
 	// Request artifacts be added to account.
-	id, err := aws.Wrap(client).AddAccountArtifacts(ctx, accountID, features, profiles, roles)
+	var roleChainingAccountID uuid.UUID
+	if id, ok := d.GetOk(keyRoleChainingAccountID); ok {
+		roleChainingAccountID, err = uuid.Parse(id.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	id, err := aws.Wrap(client).AddAccountArtifacts(ctx, accountID, features, profiles, roles, roleChainingAccountID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -184,6 +202,12 @@ func awsReadCnpAccountAttachments(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
+	// Workaround: the ROLE_CHAINING artifact is registered as a
+	// duplicate of CROSSACCOUNT by the create function. Remove it from
+	// the read response so it doesn't appear in state and cause a
+	// perpetual diff.
+	delete(roles, "ROLE_CHAINING")
+
 	oldRoles := make(map[string]string)
 	for _, role := range d.Get(keyRole).(*schema.Set).List() {
 		block := role.(map[string]any)
@@ -228,8 +252,17 @@ func awsUpdateCnpAccountAttachments(ctx context.Context, d *schema.ResourceData,
 		roles[block[keyKey].(string)] = block[keyARN].(string)
 	}
 
+	ensureRoleChainingArtifact(roles, features)
+
 	// Update artifacts.
-	_, err = aws.Wrap(client).AddAccountArtifacts(ctx, id, features, profiles, roles)
+	var roleChainingAccountID uuid.UUID
+	if id, ok := d.GetOk(keyRoleChainingAccountID); ok {
+		roleChainingAccountID, err = uuid.Parse(id.(string))
+		if err != nil {
+			return diag.FromErr(err)
+		}
+	}
+	_, err = aws.Wrap(client).AddAccountArtifacts(ctx, id, features, profiles, roles, roleChainingAccountID)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -252,6 +285,34 @@ func awsDeleteCnpAccountAttachments(ctx context.Context, d *schema.ResourceData,
 	d.SetId("")
 
 	return nil
+}
+
+// ensureRoleChainingArtifact duplicates the CROSSACCOUNT role ARN as
+// ROLE_CHAINING when the ROLE_CHAINING feature is present. This is a
+// workaround for the RSC backend not returning the ROLE_CHAINING_ROLE_ARN
+// artifact.
+func ensureRoleChainingArtifact(roles map[string]string, features []core.Feature) {
+	crossAccountARN, ok := roles["CROSSACCOUNT"]
+	if !ok {
+		return
+	}
+	if _, ok := roles["ROLE_CHAINING"]; ok {
+		return
+	}
+	if _, ok := core.LookupFeature(features, core.FeatureRoleChaining); ok {
+		roles["ROLE_CHAINING"] = crossAccountARN
+	}
+}
+
+func awsCustomizeDiffCnpAccountAttachments(ctx context.Context, diff *schema.ResourceDiff, m any) error {
+	tflog.Trace(ctx, "awsCustomizeDiffCnpAccountAttachments")
+
+	var features []core.Feature
+	for _, feature := range diff.Get(keyFeatures).(*schema.Set).List() {
+		features = append(features, core.Feature{Name: feature.(string)})
+	}
+
+	return core.ValidateRoleChaining(features)
 }
 
 func instanceProfileResource() *schema.Resource {

--- a/internal/provider/resource_aws_cnp_account_trust_policy.go
+++ b/internal/provider/resource_aws_cnp_account_trust_policy.go
@@ -298,7 +298,13 @@ func trustPolicyForRoleKey(ctx context.Context, client *polaris.Client, roleKey 
 	for _, feature := range account.Features {
 		features = append(features, feature.Feature)
 	}
-	trustPolicies, err := aws.Wrap(client).TrustPolicies(ctx, gqlaws.Cloud(account.Cloud), account.ID, features, externalID, account.RoleChainingAccountID)
+	trustPolicies, err := aws.Wrap(client).TrustPolicies(ctx, aws.TrustPoliciesParams{
+		Cloud:                 gqlaws.Cloud(account.Cloud),
+		CloudAccountID:        account.ID,
+		Features:              features,
+		ExternalID:            externalID,
+		RoleChainingAccountID: account.RoleChainingAccountID,
+	})
 	if err != nil {
 		return "", err
 	}

--- a/internal/provider/resource_aws_cnp_account_trust_policy.go
+++ b/internal/provider/resource_aws_cnp_account_trust_policy.go
@@ -298,7 +298,7 @@ func trustPolicyForRoleKey(ctx context.Context, client *polaris.Client, roleKey 
 	for _, feature := range account.Features {
 		features = append(features, feature.Feature)
 	}
-	trustPolicies, err := aws.Wrap(client).TrustPolicies(ctx, gqlaws.Cloud(account.Cloud), account.ID, features, externalID)
+	trustPolicies, err := aws.Wrap(client).TrustPolicies(ctx, gqlaws.Cloud(account.Cloud), account.ID, features, externalID, account.RoleChainingAccountID)
 	if err != nil {
 		return "", err
 	}

--- a/internal/provider/resource_aws_cnp_account_trust_policy.go
+++ b/internal/provider/resource_aws_cnp_account_trust_policy.go
@@ -46,8 +46,11 @@ required by RSC. The ´policy´ field of ´aws_cnp_account_trust_policy´ resour
 should be used with the ´assume_role_policy´ of the ´aws_iam_role´ resource.
 
 ~> **Note:** The ´polaris_aws_cnp_account´ resource can now be used to get the
-   IAM trust policies for all role keys. The ´aws_cnp_account_trust_policy´
+   IAM trust policies for all role keys. The ´polaris_aws_cnp_account_trust_policy´
    resource is no longer required and will be deprecated in a future version.
+
+~> **Note:** This resource does not support role chaining. Use the ´trust_policies´
+   field of the ´polaris_aws_cnp_account´ resource for accounts using role chaining.
 
 ~> **Note:** Once ´external_id´ has been set it cannot be changed. Unless the
    cloud account is removed and onboarded again.

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -4,6 +4,15 @@ page_title: "Changelog"
 
 # Changelog
 
+## v1.6.3
+* New data source added for `polaris_feature_flag` which checks if a feature flag is enabled for the RSC account.
+  [[docs](../data-sources/feature_flag.md)]
+* Add support for the `ROLE_CHAINING` feature and `role_chaining_account_id` field in the `polaris_aws_cnp_account` and
+  `polaris_aws_cnp_account_attachments` resources, and in the `polaris_aws_cnp_permissions` data source.
+  [[docs](../resources/aws_cnp_account.md)] [[docs](../resources/aws_cnp_account_attachments.md)]
+* Fix `storage_account_name_prefix` max length validation in the `polaris_azure_archival_location` resource. The limit
+  is now 16 characters for `SOURCE_REGION` and 24 characters for `SPECIFIC_REGION`, matching the backend constraints.
+
 ## v1.6.2
 * Fix managed identity upgrade for the `sql_db_protection` block in the `polaris_azure_subscription` resource. The
   `upgradeFeatureToUseManagedIdentity` function was not including permission groups in the SDK call, causing the Go SDK

--- a/templates/guides/upgrade_guide_v1.6.3.md.tmpl
+++ b/templates/guides/upgrade_guide_v1.6.3.md.tmpl
@@ -1,0 +1,156 @@
+---
+page_title: "Upgrade Guide: v1.6.3"
+---
+
+# Upgrade Guide v1.6.3
+
+## Before Upgrading
+
+Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
+provider.
+
+## How to Upgrade
+
+Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.6.3 release. One
+way of doing this is by using the pessimistic constraint operator `~>`, which allows Terraform to upgrade to the latest
+release within the same minor version:
+```terraform
+terraform {
+  required_providers {
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "~> 1.6.0"
+    }
+  }
+}
+```
+Next, upgrade the provider to the new version by running:
+```shell
+% terraform init -upgrade
+```
+After the provider has been updated, validate the correctness of the Terraform configuration files by running:
+```shell
+% terraform plan
+```
+If you get an error or an unwanted diff, please see the _Significant Changes_ and _New Features_ sections below for
+additional instructions. Otherwise, proceed by running:
+```shell
+% terraform apply -refresh-only
+```
+This will read the remote state of the resources and migrate the local Terraform state to the v1.6.3 version.
+
+## New Features
+
+### polaris_feature_flag data source
+
+The new `polaris_feature_flag` data source checks if a feature flag is enabled for the RSC account.
+
+```terraform
+data "polaris_feature_flag" "my_feature_flag" {
+  name = "MY_FEATURE_FLAG"
+}
+
+output "my_feature_flag_enabled" {
+  value = data.polaris_feature_flag.my_feature_flag.enabled
+}
+```
+
+For more details, see the [polaris_feature_flag documentation](../data-sources/feature_flag.md).
+
+### polaris_aws_cnp_account: role chaining support
+
+The `polaris_aws_cnp_account` and `polaris_aws_cnp_account_attachments` resources now support the `ROLE_CHAINING`
+feature and the `role_chaining_account_id` field for cross-account role chaining. The `polaris_aws_cnp_artifacts` and
+the `polaris_aws_cnp_permissions` data sources have also been updated with role chaining support.
+
+To onboard the role-chaining AWS account, use the `ROLE_CHAINING` feature with the `BASIC` permission group:
+```terraform
+# Lookup the artifacts required for the role-chaining feature.
+data "polaris_aws_cnp_artifacts" "artifacts" {
+  feature {
+    name = "ROLE_CHAINING"
+    permission_groups = [
+      "BASIC",
+    ]
+  }
+}
+
+# Lookup the permissions required for each role artifact for the
+# role-chaining feature.
+data "polaris_aws_cnp_permissions" "permissions" {
+  for_each = data.polaris_aws_cnp_artifacts.artifacts.role_keys
+  role_key = each.key
+
+  feature {
+    name = "ROLE_CHAINING"
+    permission_groups = [
+      "BASIC",
+    ]
+  }
+}
+
+# Start onboarding the specified account as the role-chaining account.
+resource "polaris_aws_cnp_account" "account" {
+  name      = "Role-chaining Account"
+  native_id = "123456789123"
+
+  feature {
+    name = "ROLE_CHAINING"
+    permission_groups = [
+      "BASIC",
+    ]
+  }
+
+  regions = [
+    "us-east-2",
+  ]
+}
+
+# At this point the AWS Terraform provider should be used to create
+# the required role artifacts. The polaris_aws_cnp_artifacts and the
+# polaris_aws_cnp_permissions data sources together with the
+# trust_policies field from the polaris_aws_cnp_account resource is
+# used as input.
+
+# Attach the role artifacts to the role-chaining account.
+resource "polaris_aws_cnp_account_attachments" "attachments" {
+  account_id = polaris_aws_cnp_account.account.id
+
+  features = [
+    "ROLE_CHAINING"
+  ]
+  
+  dynamic "role" {
+    for_each = aws_iam_role.role
+    content {
+      key         = role.key
+      arn         = role.value["arn"]
+      permissions = data.polaris_aws_cnp_permissions.permissions[role.key].id
+    }
+  }
+}
+```
+Note that the `ROLE_CHAINING` feature is mutually exclusive with all other RSC features.
+
+To onboard a role-chained AWS account, i.e. an AWS account using the role-chaining AWS account, proceed as you normally
+would when you onboard an AWS account, but pass the role-chaining RSC cloud account ID (UUID) to the
+`polaris_aws_cnp_account` and the `polaris_aws_cnp_account_attachments` resources using the `role_chaining_account_id`
+field.
+
+For a complete example of how to onboard an AWS account to RSC, look at the
+[AWS IAM account](https://github.com/rubrikinc/terraform-provider-polaris-examples/tree/main/modules/aws_iam_account)
+module in the [examples](https://github.com/rubrikinc/terraform-provider-polaris-examples/tree/main) repository. 
+
+Note that the `polaris_aws_cnp_account_trust_policy` resource does not support role chaining. Use the `trust_policies`
+field of the `polaris_aws_cnp_account` resource when using role chaining.
+
+For more details, see the [polaris_aws_cnp_account documentation](../resources/aws_cnp_account.md) and the
+[polaris_aws_cnp_account_attachments documentation](../resources/aws_cnp_account_attachments.md).
+
+## Bug Fixes
+
+### polaris_azure_archival_location: storage_account_name_prefix max length fix
+
+The `storage_account_name_prefix` field was hardcoded to a maximum of 14 characters, but the backend accepts up to 16
+for `SOURCE_REGION` (prefix + 8-character UID = 24, Azure's max) and up to 24 for `SPECIFIC_REGION` (name used
+directly). The provider now enforces the correct limit based on whether `storage_account_region` is set.

--- a/templates/resources/aws_cnp_account.md.tmpl
+++ b/templates/resources/aws_cnp_account.md.tmpl
@@ -29,6 +29,7 @@ description: |-
 - `delete_snapshots_on_destroy` (Boolean) Should snapshots be deleted when the resource is destroyed.
 - `external_id` (String) External ID. Changing this forces a new resource to be created.
 - `name` (String) Account name.
+- `role_chaining_account_id` (String) RSC cloud account ID of the role chaining account. When specified, the account will use cross-account role chaining. Changing this forces a new resource to be created.
 
 ### Read-Only
 


### PR DESCRIPTION
# Description

Add AWS role chaining support to the IAM roles workflow. This adds `ROLE_CHAINING` as a valid feature with mutual exclusivity enforced via `CustomizeDiff`, and adds `role_chaining_account_id` to the account and attachments resources to support onboarding AWS accounts linked to a role chaining account.

Includes workarounds for the RSC backend not returning the `sts:AssumeRole` permission policy or the `ROLE_CHAINING_ROLE_ARN` artifact for the `ROLE_CHAINING` feature. Both workarounds are self-removing once the backend is fixed.

## Related Issue

Depends on rubrikinc/rubrik-polaris-sdk-for-go#357.

## Motivation and Context

AWS role chaining introduces a mediator account between RSC and customer AWS accounts, allowing customers to revoke Rubrik's access to all accounts by modifying a single trust policy. The provider needs to pass the `roleChainingAccountId` to the trust policy and artifact registration endpoints, and work around missing backend data for the `ROLE_CHAINING` feature.

## How Has This Been Tested?

Manually tested against a dev RSC instance by onboarding a role chaining account and a mapped account using the `aws_iam_account` example module. All unit tests pass.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
