### PR TITLE
Add frequency field to SLA domain archival block

### DIFF
--- a/docs/data-sources/sla_domain.md
+++ b/docs/data-sources/sla_domain.md
@@ -70,6 +70,7 @@ Read-Only:
 
 - `archival_location_id` (String) Archival location ID (UUID).
 - `archival_location_to_cluster_mapping` (List of Object) Mapping between archival location and Rubrik cluster. (see [below for nested schema](#nestedatt--archival--archival_location_to_cluster_mapping))
+- `frequency` (Set of String) Effective snapshot frequencies being archived.
 - `threshold` (Number) Threshold specifies the time before archiving the snapshots at the managing location.
 - `threshold_unit` (String) Threshold unit specifies the unit of threshold.
 

--- a/docs/resources/sla_domain.md
+++ b/docs/resources/sla_domain.md
@@ -302,6 +302,7 @@ Optional:
 - `archival_location_id` (String) Archival location ID (UUID).
 - `archival_location_to_cluster_mapping` (Block List) Mapping between archival location and Rubrik cluster. Each mapping specifies which cluster should be used for archiving to a specific location. (see [below for nested schema](#nestedblock--archival--archival_location_to_cluster_mapping))
 - `archival_tiering` (Block List, Max: 1) Archival tiering specification for cold storage. (see [below for nested schema](#nestedblock--archival--archival_tiering))
+- `frequency` (Set of String) Override which snapshot frequencies to archive. When not specified, frequencies are derived from the snapshot schedule and will not be visible in state. Use the [polaris_sla_domain](../data-sources/sla_domain.md) data source to see the effective frequencies. Possible values are `MINUTES`, `HOURS`, `DAYS`, `WEEKS`, `MONTHS`, `QUARTERS`, `YEARS`.
 - `threshold` (Number) Threshold specifies the time before archiving the snapshots at the managing location. The archival location retains the snapshots according to the SLA Domain schedule.
 - `threshold_unit` (String) Threshold unit specifies the unit of `threshold`. Possible values are `DAYS`, `WEEKS`, `MONTHS` and `YEARS`. Default value is `DAYS`.
 
@@ -635,7 +636,7 @@ Optional:
 - `archival_threshold` (Number) Archival threshold specifies when to archive replicated snapshots.
 - `archival_threshold_unit` (String) Archival threshold unit. Possible values are `DAYS`, `WEEKS`, `MONTHS`, `QUARTERS` and `YEARS`.
 - `archival_tiering` (Block List, Max: 1) Archival tiering specification for cold storage. (see [below for nested schema](#nestedblock--replication_spec--cascading_archival--archival_tiering))
-- `frequency` (Set of String) Frequencies for cascading archival. Possible values are `MINUTE`, `HOURS`, `DAYS`, `WEEKS`, `MONTHS`, `QUARTERS`, `YEARS`.
+- `frequency` (Set of String) Frequencies for cascading archival. Possible values are `MINUTES`, `HOURS`, `DAYS`, `WEEKS`, `MONTHS`, `QUARTERS`, `YEARS`.
 
 <a id="nestedblock--replication_spec--cascading_archival--archival_tiering"></a>
 ### Nested Schema for `replication_spec.cascading_archival.archival_tiering`

--- a/internal/provider/data_source_sla_domain.go
+++ b/internal/provider/data_source_sla_domain.go
@@ -150,6 +150,14 @@ func dataSourceSLADomain() *schema.Resource {
 							Computed:    true,
 							Description: "Archival tiering specification for cold storage.",
 						},
+						keyFrequency: {
+							Type: schema.TypeSet,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+							},
+							Computed:    true,
+							Description: "Effective snapshot frequencies being archived.",
+						},
 					},
 				},
 				Computed:    true,

--- a/internal/provider/resource_sla_domain.go
+++ b/internal/provider/resource_sla_domain.go
@@ -246,6 +246,27 @@ func resourceSLADomain() *schema.Resource {
 							Optional:    true,
 							Description: "Archival tiering specification for cold storage.",
 						},
+						keyFrequency: {
+							Type: schema.TypeSet,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								ValidateFunc: validation.StringInSlice([]string{
+									string(gqlsla.Minute),
+									string(gqlsla.Hours),
+									string(gqlsla.Days),
+									string(gqlsla.Weeks),
+									string(gqlsla.Months),
+									string(gqlsla.Quarters),
+									string(gqlsla.Years),
+								}, false),
+							},
+							Optional: true,
+							Description: "Override which snapshot frequencies to archive. When not specified, " +
+								"frequencies are derived from the snapshot schedule and will not be visible " +
+								"in state. Use the polaris_sla_domain data source to see the effective " +
+								"frequencies. Possible values are `MINUTES`, `HOURS`, `DAYS`, `WEEKS`, " +
+								"`MONTHS`, `QUARTERS`, `YEARS`.",
+						},
 					},
 				},
 				Optional: true,
@@ -1650,9 +1671,20 @@ func fromArchival(d *schema.ResourceData, schedule gqlsla.SnapshotSchedule) ([]g
 			}
 		}
 
+		// Parse frequencies — use user-specified values if provided,
+		// otherwise derive from the snapshot schedule.
+		var frequencies []gqlsla.RetentionUnit
+		if freqSet, ok := archival[keyFrequency].(*schema.Set); ok && freqSet.Len() > 0 {
+			for _, freq := range freqSet.List() {
+				frequencies = append(frequencies, gqlsla.RetentionUnit(freq.(string)))
+			}
+		} else {
+			frequencies = frequenciesFromSchedule(schedule)
+		}
+
 		archivalSpecs = append(archivalSpecs, gqlsla.ArchivalSpec{
 			GroupID:                          groupID,
-			Frequencies:                      frequenciesFromSchedule(schedule),
+			Frequencies:                      frequencies,
 			Threshold:                        archival[keyThreshold].(int),
 			ThresholdUnit:                    gqlsla.RetentionUnit(archival[keyThresholdUnit].(string)),
 			ArchivalLocationToClusterMapping: mappings,
@@ -1699,6 +1731,16 @@ func toArchival(domain gqlsla.Domain, existing []any) ([]any, error) {
 				keyTierExistingSnapshots:          spec.ArchivalTieringSpec.TierExistingSnapshots,
 			}
 			block[keyArchivalTiering] = []any{tieringMap}
+		}
+
+		if len(spec.Frequencies) > 0 {
+			frequencies := &schema.Set{F: schema.HashString}
+			for _, freq := range spec.Frequencies {
+				frequencies.Add(string(freq))
+			}
+			block[keyFrequency] = frequencies
+		} else {
+			block[keyFrequency] = nil
 		}
 
 		blocks[id] = block
@@ -2429,10 +2471,29 @@ func readSLADomain(ctx context.Context, d *schema.ResourceData, m any) diag.Diag
 		return diag.FromErr(err)
 	}
 
-	archival, err := toArchival(slaDomain, d.Get(keyArchival).([]any))
+	existing := d.Get(keyArchival).([]any)
+	archival, err := toArchival(slaDomain, existing)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+
+	// Only persist frequencies to resource state when the user explicitly
+	// configured them. This avoids a perpetual diff when the provider
+	// derives frequencies from the snapshot schedule.
+	explicitFreqs := make(map[string]bool)
+	for _, old := range existing {
+		oldBlock := old.(map[string]any)
+		if freqSet, ok := oldBlock[keyFrequency].(*schema.Set); ok && freqSet.Len() > 0 {
+			explicitFreqs[oldBlock[keyArchivalLocationID].(string)] = true
+		}
+	}
+	for _, a := range archival {
+		block := a.(map[string]any)
+		if !explicitFreqs[block[keyArchivalLocationID].(string)] {
+			block[keyFrequency] = nil
+		}
+	}
+
 	if err := d.Set(keyArchival, archival); err != nil {
 		return diag.FromErr(err)
 	}

--- a/templates/data-sources/sla_domain.md.tmpl
+++ b/templates/data-sources/sla_domain.md.tmpl
@@ -54,6 +54,7 @@ Read-Only:
 
 - `archival_location_id` (String) Archival location ID (UUID).
 - `archival_location_to_cluster_mapping` (List of Object) Mapping between archival location and Rubrik cluster. (see [below for nested schema](#nestedatt--archival--archival_location_to_cluster_mapping))
+- `frequency` (Set of String) Effective snapshot frequencies being archived.
 - `threshold` (Number) Threshold specifies the time before archiving the snapshots at the managing location.
 - `threshold_unit` (String) Threshold unit specifies the unit of threshold.
 

--- a/templates/resources/sla_domain.md.tmpl
+++ b/templates/resources/sla_domain.md.tmpl
@@ -73,6 +73,7 @@ Optional:
 - `archival_location_id` (String) Archival location ID (UUID).
 - `archival_location_to_cluster_mapping` (Block List) Mapping between archival location and Rubrik cluster. Each mapping specifies which cluster should be used for archiving to a specific location. (see [below for nested schema](#nestedblock--archival--archival_location_to_cluster_mapping))
 - `archival_tiering` (Block List, Max: 1) Archival tiering specification for cold storage. (see [below for nested schema](#nestedblock--archival--archival_tiering))
+- `frequency` (Set of String) Override which snapshot frequencies to archive. When not specified, frequencies are derived from the snapshot schedule and will not be visible in state. Use the [polaris_sla_domain](../data-sources/sla_domain.md) data source to see the effective frequencies. Possible values are `MINUTES`, `HOURS`, `DAYS`, `WEEKS`, `MONTHS`, `QUARTERS`, `YEARS`.
 - `threshold` (Number) Threshold specifies the time before archiving the snapshots at the managing location. The archival location retains the snapshots according to the SLA Domain schedule.
 - `threshold_unit` (String) Threshold unit specifies the unit of `threshold`. Possible values are `DAYS`, `WEEKS`, `MONTHS` and `YEARS`. Default value is `DAYS`.
 
@@ -406,7 +407,7 @@ Optional:
 - `archival_threshold` (Number) Archival threshold specifies when to archive replicated snapshots.
 - `archival_threshold_unit` (String) Archival threshold unit. Possible values are `DAYS`, `WEEKS`, `MONTHS`, `QUARTERS` and `YEARS`.
 - `archival_tiering` (Block List, Max: 1) Archival tiering specification for cold storage. (see [below for nested schema](#nestedblock--replication_spec--cascading_archival--archival_tiering))
-- `frequency` (Set of String) Frequencies for cascading archival. Possible values are `MINUTE`, `HOURS`, `DAYS`, `WEEKS`, `MONTHS`, `QUARTERS`, `YEARS`.
+- `frequency` (Set of String) Frequencies for cascading archival. Possible values are `MINUTES`, `HOURS`, `DAYS`, `WEEKS`, `MONTHS`, `QUARTERS`, `YEARS`.
 
 <a id="nestedblock--replication_spec--cascading_archival--archival_tiering"></a>
 ### Nested Schema for `replication_spec.cascading_archival.archival_tiering`


### PR DESCRIPTION
# Description

Allow users to override which snapshot frequencies are archived instead of always deriving them from the snapshot schedule. When not specified, behavior is unchanged. Also expose effective frequencies as a computed field on the polaris_sla_domain data source.

Includes a V0-to-V1 state upgrade and fixes a typo in the cascading archival docs (MINUTE -> MINUTES).

## Related Issue

Fixes #428 

## How Has This Been Tested?

Manually

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
