### PR TITLE
Add SLA domain frequency field to v1.6.3 release docs

### DIFF
--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -10,6 +10,9 @@ page_title: "Changelog"
 * Add support for the `ROLE_CHAINING` feature and `role_chaining_account_id` field in the `polaris_aws_cnp_account` and
   `polaris_aws_cnp_account_attachments` resources, and in the `polaris_aws_cnp_permissions` data source.
   [[docs](../resources/aws_cnp_account.md)] [[docs](../resources/aws_cnp_account_attachments.md)]
+* Add `frequency` field to the `archival` block in the `polaris_sla_domain` resource. The field allows overriding which
+  snapshot frequencies are archived instead of deriving them from the snapshot schedule.
+  [[docs](../resources/sla_domain.md)]
 * Fix `storage_account_name_prefix` max length validation in the `polaris_azure_archival_location` resource. The limit
   is now 16 characters for `SOURCE_REGION` and 24 characters for `SPECIFIC_REGION`, matching the backend constraints.
 

--- a/docs/guides/upgrade_guide_v1.6.3.md
+++ b/docs/guides/upgrade_guide_v1.6.3.md
@@ -147,6 +147,32 @@ field of the `polaris_aws_cnp_account` resource when using role chaining.
 For more details, see the [polaris_aws_cnp_account documentation](../resources/aws_cnp_account.md) and the
 [polaris_aws_cnp_account_attachments documentation](../resources/aws_cnp_account_attachments.md).
 
+### polaris_sla_domain: archival frequency override
+
+The `archival` block in the `polaris_sla_domain` resource now supports a `frequency` field that allows overriding which
+snapshot frequencies are archived. When not specified, frequencies are derived from the snapshot schedule as before.
+
+```terraform
+resource "polaris_sla_domain" "example" {
+  # ...
+
+  archival {
+    archival_location_id = polaris_aws_archival_location.example.id
+    threshold            = 30
+    threshold_unit       = "DAYS"
+
+    frequency = [
+      "DAYS",
+      "WEEKS",
+    ]
+  }
+}
+```
+
+The effective frequencies can be read back using the `polaris_sla_domain` data source.
+
+For more details, see the [polaris_sla_domain documentation](../resources/sla_domain.md).
+
 ## Bug Fixes
 
 ### polaris_azure_archival_location: storage_account_name_prefix max length fix

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -10,6 +10,9 @@ page_title: "Changelog"
 * Add support for the `ROLE_CHAINING` feature and `role_chaining_account_id` field in the `polaris_aws_cnp_account` and
   `polaris_aws_cnp_account_attachments` resources, and in the `polaris_aws_cnp_permissions` data source.
   [[docs](../resources/aws_cnp_account.md)] [[docs](../resources/aws_cnp_account_attachments.md)]
+* Add `frequency` field to the `archival` block in the `polaris_sla_domain` resource. The field allows overriding which
+  snapshot frequencies are archived instead of deriving them from the snapshot schedule.
+  [[docs](../resources/sla_domain.md)]
 * Fix `storage_account_name_prefix` max length validation in the `polaris_azure_archival_location` resource. The limit
   is now 16 characters for `SOURCE_REGION` and 24 characters for `SPECIFIC_REGION`, matching the backend constraints.
 

--- a/templates/guides/upgrade_guide_v1.6.3.md.tmpl
+++ b/templates/guides/upgrade_guide_v1.6.3.md.tmpl
@@ -147,6 +147,32 @@ field of the `polaris_aws_cnp_account` resource when using role chaining.
 For more details, see the [polaris_aws_cnp_account documentation](../resources/aws_cnp_account.md) and the
 [polaris_aws_cnp_account_attachments documentation](../resources/aws_cnp_account_attachments.md).
 
+### polaris_sla_domain: archival frequency override
+
+The `archival` block in the `polaris_sla_domain` resource now supports a `frequency` field that allows overriding which
+snapshot frequencies are archived. When not specified, frequencies are derived from the snapshot schedule as before.
+
+```terraform
+resource "polaris_sla_domain" "example" {
+  # ...
+
+  archival {
+    archival_location_id = polaris_aws_archival_location.example.id
+    threshold            = 30
+    threshold_unit       = "DAYS"
+
+    frequency = [
+      "DAYS",
+      "WEEKS",
+    ]
+  }
+}
+```
+
+The effective frequencies can be read back using the `polaris_sla_domain` data source.
+
+For more details, see the [polaris_sla_domain documentation](../resources/sla_domain.md).
+
 ## Bug Fixes
 
 ### polaris_azure_archival_location: storage_account_name_prefix max length fix


### PR DESCRIPTION
# Description

Add the missing changelog entry and upgrade guide section for the `frequency` field added to the `archival` block in the `polaris_sla_domain` resource (#430).

## Motivation and Context

The v1.6.3 changelog and upgrade guide were missing documentation for the SLA domain archival frequency override feature.

## How Has This Been Tested?

Documentation-only change, no code modified.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.