### PR TITLE
Sla domain omit empty retention

### DIFF
--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -15,6 +15,9 @@ page_title: "Changelog"
   `polaris_sla_domain` resource. Optional retention unit fields now mirror the schema default when the matching
   duration is unset, and the `storage_snapshot_config` block in `sap_hana_config` is only emitted when it has data.
   This removes spurious diffs after apply.
+* Set the default for `log_archival_method` in the `db2_config` block of the `polaris_sla_domain` resource to
+  `LOGARCHMETH1`, matching the RSC backend default. Previously, omitting the field produced a drift on subsequent
+  plans because the API returned `LOGARCHMETH1` while the schema treated the field as unset.
 
 ## v1.6.3
 * New data source added for `polaris_feature_flag` which checks if a feature flag is enabled for the RSC account.

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -7,6 +7,14 @@ page_title: "Changelog"
 ## v1.7.0
 * Add Terraform search support for the `polaris_custom_role` resource. Enables `terraform query` to discover custom
   roles in RSC, including roles not managed by Terraform.
+* Improve handling of optional retention fields in the object-specific configuration blocks of the
+  `polaris_sla_domain` resource (`sap_hana_config`, `db2_config`, `mssql_config`, `oracle_config`, `mongo_config`,
+  `managed_volume_config`, `postgres_db_cluster_config`, `mysql_config`, `informix_config`, `gcp_cloud_sql_config`).
+  Omitted retention fields are now left out of the API request instead of being sent with empty values.
+* Improve state refresh for the `sap_hana_config`, `db2_config`, `oracle_config` and `informix_config` blocks of the
+  `polaris_sla_domain` resource. Optional retention unit fields now mirror the schema default when the matching
+  duration is unset, and the `storage_snapshot_config` block in `sap_hana_config` is only emitted when it has data.
+  This removes spurious diffs after apply.
 
 ## v1.6.3
 * New data source added for `polaris_feature_flag` which checks if a feature flag is enabled for the RSC account.

--- a/docs/resources/sla_domain.md
+++ b/docs/resources/sla_domain.md
@@ -409,7 +409,7 @@ Optional:
 - `differential_frequency_unit` (String) Differential frequency unit. Possible values are `DAYS`, `WEEKS`, `MONTHS`, `YEARS`. Default is `DAYS`.
 - `incremental_frequency` (Number) Incremental backup frequency.
 - `incremental_frequency_unit` (String) Incremental frequency unit. Possible values are `DAYS`, `WEEKS`, `MONTHS`, `YEARS`. Default is `DAYS`.
-- `log_archival_method` (String) Log archival method. Possible values are `LOGARCHMETH1`, `LOGARCHMETH2`.
+- `log_archival_method` (String) Log archival method. Possible values are `LOGARCHMETH1`, `LOGARCHMETH2`. Default is `LOGARCHMETH1`.
 - `log_retention` (Number) Log retention duration.
 - `log_retention_unit` (String) Log retention unit. Possible values are `DAYS`, `WEEKS`, `MONTHS`, `YEARS`. Default is `DAYS`.
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.22.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.5.0
+	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.5.1-0.20260422113418-c1e5b1a16f40
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.5.0 h1:OYAPQMSHfnJ3ttJh4YdnLcluyH5Zubn5cViAXOWnJDY=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.5.0/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.5.1-0.20260422113418-c1e5b1a16f40 h1:MVd9KQV1TWE3lQFbLeJ6DbymqRm0+TVtHXkXLbRrvHs=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.5.1-0.20260422113418-c1e5b1a16f40/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/internal/provider/resource_sla_domain.go
+++ b/internal/provider/resource_sla_domain.go
@@ -519,7 +519,8 @@ func resourceSLADomain() *schema.Resource {
 						keyLogArchivalMethod: {
 							Type:         schema.TypeString,
 							Optional:     true,
-							Description:  "Log archival method. Possible values are `LOGARCHMETH1`, `LOGARCHMETH2`.",
+							Default:      string(gqlsla.Db2LogArchivalMethod1),
+							Description:  "Log archival method. Possible values are `LOGARCHMETH1`, `LOGARCHMETH2`. Default is `LOGARCHMETH1`.",
 							ValidateFunc: validation.StringInSlice([]string{"LOGARCHMETH1", "LOGARCHMETH2"}, false),
 						},
 					},

--- a/internal/provider/resource_sla_domain.go
+++ b/internal/provider/resource_sla_domain.go
@@ -2944,25 +2944,32 @@ func toSapHanaConfig(config *gqlsla.SapHanaConfig) []any {
 		return nil
 	}
 
-	result := map[string]any{}
+	// Pre-seed unit fields with the schema's Default to avoid drift when the
+	// matching duration is unset. The Default is injected during plan, not
+	// during d.Set(), so state must carry the same value after refresh.
+	result := map[string]any{
+		keyIncrementalFrequencyUnit:  string(gqlsla.Days),
+		keyLogRetentionUnit:          string(gqlsla.Days),
+		keyDifferentialFrequencyUnit: string(gqlsla.Days),
+	}
 	if config.IncrementalFrequency.Duration > 0 {
 		result[keyIncrementalFrequency] = config.IncrementalFrequency.Duration
-		result[keyIncrementalFrequencyUnit] = config.IncrementalFrequency.Unit
+		result[keyIncrementalFrequencyUnit] = string(config.IncrementalFrequency.Unit)
 	}
 	if config.LogRetention.Duration > 0 {
 		result[keyLogRetention] = config.LogRetention.Duration
-		result[keyLogRetentionUnit] = config.LogRetention.Unit
+		result[keyLogRetentionUnit] = string(config.LogRetention.Unit)
 	}
 	if config.DifferentialFrequency.Duration > 0 {
 		result[keyDifferentialFrequency] = config.DifferentialFrequency.Duration
-		result[keyDifferentialFrequencyUnit] = config.DifferentialFrequency.Unit
+		result[keyDifferentialFrequencyUnit] = string(config.DifferentialFrequency.Unit)
 	}
-	if config.StorageSnapshotConfig != nil {
+	if c := config.StorageSnapshotConfig; c != nil && (c.Frequency.Duration > 0 || c.Retention.Duration > 0) {
 		result[keyStorageSnapshotConfig] = []any{map[string]any{
-			keyFrequency:     config.StorageSnapshotConfig.Frequency.Duration,
-			keyFrequencyUnit: config.StorageSnapshotConfig.Frequency.Unit,
-			keyRetention:     config.StorageSnapshotConfig.Retention.Duration,
-			keyRetentionUnit: config.StorageSnapshotConfig.Retention.Unit,
+			keyFrequency:     c.Frequency.Duration,
+			keyFrequencyUnit: string(c.Frequency.Unit),
+			keyRetention:     c.Retention.Duration,
+			keyRetentionUnit: string(c.Retention.Unit),
 		}}
 	}
 
@@ -3012,18 +3019,22 @@ func toDB2Config(config *gqlsla.DB2Config) []any {
 		return nil
 	}
 
-	result := map[string]any{}
+	result := map[string]any{
+		keyIncrementalFrequencyUnit:  string(gqlsla.Days),
+		keyLogRetentionUnit:          string(gqlsla.Days),
+		keyDifferentialFrequencyUnit: string(gqlsla.Days),
+	}
 	if config.IncrementalFrequency.Duration > 0 {
 		result[keyIncrementalFrequency] = config.IncrementalFrequency.Duration
-		result[keyIncrementalFrequencyUnit] = config.IncrementalFrequency.Unit
+		result[keyIncrementalFrequencyUnit] = string(config.IncrementalFrequency.Unit)
 	}
 	if config.LogRetention.Duration > 0 {
 		result[keyLogRetention] = config.LogRetention.Duration
-		result[keyLogRetentionUnit] = config.LogRetention.Unit
+		result[keyLogRetentionUnit] = string(config.LogRetention.Unit)
 	}
 	if config.DifferentialFrequency.Duration > 0 {
 		result[keyDifferentialFrequency] = config.DifferentialFrequency.Duration
-		result[keyDifferentialFrequencyUnit] = config.DifferentialFrequency.Unit
+		result[keyDifferentialFrequencyUnit] = string(config.DifferentialFrequency.Unit)
 	}
 	if config.LogArchivalMethod != "" {
 		result[keyLogArchivalMethod] = string(config.LogArchivalMethod)
@@ -3106,15 +3117,16 @@ func toOracleConfig(config *gqlsla.OracleConfig) []any {
 	}
 
 	result := map[string]any{
-		keyFrequency:        config.Frequency.Duration,
-		keyFrequencyUnit:    config.Frequency.Unit,
-		keyLogRetention:     config.LogRetention.Duration,
-		keyLogRetentionUnit: config.LogRetention.Unit,
+		keyFrequency:            config.Frequency.Duration,
+		keyFrequencyUnit:        string(config.Frequency.Unit),
+		keyLogRetention:         config.LogRetention.Duration,
+		keyLogRetentionUnit:     string(config.LogRetention.Unit),
+		keyHostLogRetentionUnit: string(gqlsla.Days),
 	}
 
 	if config.HostLogRetention.Duration > 0 {
 		result[keyHostLogRetention] = config.HostLogRetention.Duration
-		result[keyHostLogRetentionUnit] = config.HostLogRetention.Unit
+		result[keyHostLogRetentionUnit] = string(config.HostLogRetention.Unit)
 	}
 
 	return []any{result}
@@ -3298,22 +3310,27 @@ func toInformixConfig(config *gqlsla.InformixSlaConfig) []any {
 		return nil
 	}
 
-	result := map[string]any{}
+	result := map[string]any{
+		keyIncrementalFrequencyUnit: string(gqlsla.Days),
+		keyIncrementalRetentionUnit: string(gqlsla.Days),
+		keyFrequencyUnit:            string(gqlsla.Days),
+		keyRetentionUnit:            string(gqlsla.Days),
+	}
 	if config.IncrementalFrequency.Duration > 0 {
 		result[keyIncrementalFrequency] = config.IncrementalFrequency.Duration
-		result[keyIncrementalFrequencyUnit] = config.IncrementalFrequency.Unit
+		result[keyIncrementalFrequencyUnit] = string(config.IncrementalFrequency.Unit)
 	}
 	if config.IncrementalRetention.Duration > 0 {
 		result[keyIncrementalRetention] = config.IncrementalRetention.Duration
-		result[keyIncrementalRetentionUnit] = config.IncrementalRetention.Unit
+		result[keyIncrementalRetentionUnit] = string(config.IncrementalRetention.Unit)
 	}
 	if config.LogFrequency.Duration > 0 {
 		result[keyFrequency] = config.LogFrequency.Duration
-		result[keyFrequencyUnit] = config.LogFrequency.Unit
+		result[keyFrequencyUnit] = string(config.LogFrequency.Unit)
 	}
 	if config.LogRetention.Duration > 0 {
 		result[keyRetention] = config.LogRetention.Duration
-		result[keyRetentionUnit] = config.LogRetention.Unit
+		result[keyRetentionUnit] = string(config.LogRetention.Unit)
 	}
 
 	return []any{result}

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -15,6 +15,9 @@ page_title: "Changelog"
   `polaris_sla_domain` resource. Optional retention unit fields now mirror the schema default when the matching
   duration is unset, and the `storage_snapshot_config` block in `sap_hana_config` is only emitted when it has data.
   This removes spurious diffs after apply.
+* Set the default for `log_archival_method` in the `db2_config` block of the `polaris_sla_domain` resource to
+  `LOGARCHMETH1`, matching the RSC backend default. Previously, omitting the field produced a drift on subsequent
+  plans because the API returned `LOGARCHMETH1` while the schema treated the field as unset.
 
 ## v1.6.3
 * New data source added for `polaris_feature_flag` which checks if a feature flag is enabled for the RSC account.

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -7,6 +7,14 @@ page_title: "Changelog"
 ## v1.7.0
 * Add Terraform search support for the `polaris_custom_role` resource. Enables `terraform query` to discover custom
   roles in RSC, including roles not managed by Terraform.
+* Improve handling of optional retention fields in the object-specific configuration blocks of the
+  `polaris_sla_domain` resource (`sap_hana_config`, `db2_config`, `mssql_config`, `oracle_config`, `mongo_config`,
+  `managed_volume_config`, `postgres_db_cluster_config`, `mysql_config`, `informix_config`, `gcp_cloud_sql_config`).
+  Omitted retention fields are now left out of the API request instead of being sent with empty values.
+* Improve state refresh for the `sap_hana_config`, `db2_config`, `oracle_config` and `informix_config` blocks of the
+  `polaris_sla_domain` resource. Optional retention unit fields now mirror the schema default when the matching
+  duration is unset, and the `storage_snapshot_config` block in `sap_hana_config` is only emitted when it has data.
+  This removes spurious diffs after apply.
 
 ## v1.6.3
 * New data source added for `polaris_feature_flag` which checks if a feature flag is enabled for the RSC account.

--- a/templates/resources/sla_domain.md.tmpl
+++ b/templates/resources/sla_domain.md.tmpl
@@ -180,7 +180,7 @@ Optional:
 - `differential_frequency_unit` (String) Differential frequency unit. Possible values are `DAYS`, `WEEKS`, `MONTHS`, `YEARS`. Default is `DAYS`.
 - `incremental_frequency` (Number) Incremental backup frequency.
 - `incremental_frequency_unit` (String) Incremental frequency unit. Possible values are `DAYS`, `WEEKS`, `MONTHS`, `YEARS`. Default is `DAYS`.
-- `log_archival_method` (String) Log archival method. Possible values are `LOGARCHMETH1`, `LOGARCHMETH2`.
+- `log_archival_method` (String) Log archival method. Possible values are `LOGARCHMETH1`, `LOGARCHMETH2`. Default is `LOGARCHMETH1`.
 - `log_retention` (Number) Log retention duration.
 - `log_retention_unit` (String) Log retention unit. Possible values are `DAYS`, `WEEKS`, `MONTHS`, `YEARS`. Default is `DAYS`.
 


### PR DESCRIPTION
# Description

Omit unset retention fields from API requests (sap_hana_config, db2_config, mssql_config, oracle_config, mongo_config, managed_volume_config, postgres_db_cluster_config, mysql_config, informix_config, gcp_cloud_sql_config): Unset optional retention fields are now omitted from API requests entirely rather than sent as empty enum values. This surfaces via the Go SDK version bump in this PR.

Improve state refresh for retention unit fields (sap_hana_config, db2_config, oracle_config, informix_config): The to*Config read helpers now pre-seed optional retention unit fields with the schema default ("DAYS") when the matching duration is unset, so state consistently mirrors what the schema produces after plan and spurious diffs are eliminated. The storage_snapshot_config nested block in toSapHanaConfig is also now only emitted when its frequency or retention duration is non-zero.

Align db2_config.log_archival_method default with the RSC backend: The schema Default for log_archival_method is now set to LOGARCHMETH1, matching the RSC backend default. This ensures that omitting the field produces stable state across plan and apply cycles.

## How Has This Been Tested?
Manual acceptance testing against a live RSC environment using TF_ACC=1. Verified that creating an SLA domain with object-specific config blocks and omitting optional retention fields produces no diff on subsequent plans.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
