### PR TITLE
Add CDM data center acceptance tests

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -105,6 +105,7 @@ Use the existing third-party UUID dependency for all UUID operations. Do not wri
 - Test function names use camelCase: `TestAccPolarisAwsAccount_basic`
 - Prefer fakes over mocks for dependencies
 - Cloud-specific tests require config files: `TEST_AWSACCOUNT_FILE`, `TEST_AZURESUBSCRIPTION_FILE`, `TEST_GCPPROJECT_FILE`, `TEST_RSCCONFIG_FILE`
+- CDM (Data Center) tests are gated behind the `cdm` build tag and require `TEST_DATACENTER_FILE`. Passing `-tags=cdm` includes them alongside the default suite (it does not replace it). Run with `TF_ACC=1 go test -tags=cdm ./...`
 
 ## Go SDK Dependency
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,10 +80,10 @@ pipeline {
             steps {
                 sh 'go version' // Log Go version used.
                 sh 'go mod tidy'
-                sh 'go vet ./...'
+                sh 'go vet -tags=cdm ./...'
                 sh 'go generate ./... >/dev/null'
                 sh 'git diff --exit-code || (echo "Generated files are out of sync. Please run go generate and commit the changes." && exit 1)'
-                sh 'GOTOOLCHAIN=$(go env GOVERSION) go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...'
+                sh 'GOTOOLCHAIN=$(go env GOVERSION) go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 -tags=cdm ./...'
                 sh 'bash -c "diff -u <(echo -n) <(gofmt -d .)"'
             }
         }
@@ -107,7 +107,7 @@ pipeline {
         }
         stage('Test') {
             steps {
-                sh 'if [ "$TF_ACC" != "true" ]; then unset TF_ACC; fi; CGO_ENABLED=0 go test -count=1 -timeout=120m -v ./...'
+                sh 'if [ "$TF_ACC" != "true" ]; then unset TF_ACC; fi; CGO_ENABLED=0 go test -skip=^TestAccCDM -count=1 -timeout=120m -v ./...'
             }
         }
     }

--- a/internal/provider/cdm_canary_test.go
+++ b/internal/provider/cdm_canary_test.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//go:build !cdm
+
+package provider
+
+import (
+	"os"
+	"testing"
+)
+
+// TestAccCDMCanary fires whenever the package is tested without the cdm
+// build tag, ensuring CDM (Data Center) acceptance coverage isn't
+// silently dropped. The TestAccCDM prefix lets the same -run/-skip
+// filters used for real CDM tests also control this canary.
+func TestAccCDMCanary(t *testing.T) {
+	if os.Getenv("TF_ACC") == "" {
+		t.Skip("Acceptance tests skipped unless env 'TF_ACC' set")
+	}
+	t.Fatal(`Data Center acceptance tests were excluded from this build.
+
+To include them, add the cdm build tag:
+    TF_ACC=1 go test -tags=cdm ./...
+
+To run the rest of the suite while excluding all TestAccCDM* tests:
+    go test -skip '^TestAccCDM' ./...`)
+}

--- a/internal/provider/cdm_fixtures_test.go
+++ b/internal/provider/cdm_fixtures_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//go:build cdm
+
+package provider
+
+import "github.com/google/uuid"
+
+// testDataCenter holds the CDM cluster and archival location
+// configuration loaded from TEST_DATACENTER_FILE.
+type testDataCenter struct {
+	ClusterUUID       uuid.UUID              `json:"clusterUuid"`
+	ClusterIP         string                 `json:"clusterIp"`
+	ArchivalLocations []testArchivalLocation `json:"archivalLocations"`
+}
+
+// testArchivalLocation represents a single archival location on the
+// CDM cluster.
+type testArchivalLocation struct {
+	LocationID   string `json:"locationId"`
+	LocationName string `json:"locationName"`
+	LocationType string `json:"locationType"`
+	Bucket       string `json:"bucket"`
+}
+
+// testDataCenterArchivalLocation is the per-subtest view passed to a
+// Terraform template, pairing the cluster with one archival location.
+type testDataCenterArchivalLocation struct {
+	ClusterUUID uuid.UUID
+	ClusterIP   string
+	testArchivalLocation
+}
+
+// loadDataCenterTestConfig loads a Data Center (CDM) test configuration
+// using the default environment variables.
+func loadDataCenterTestConfig() (testConfig, testDataCenter, error) {
+	dc := testDataCenter{}
+	config, err := loadTestConfig("RUBRIK_POLARIS_SERVICEACCOUNT_FILE", "TEST_DATACENTER_FILE", &dc)
+
+	return config, dc, err
+}

--- a/internal/provider/data_source_data_center_archival_location_cdm_test.go
+++ b/internal/provider/data_source_data_center_archival_location_cdm_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+//go:build cdm
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+const dataCenterArchivalLocationTmpl = `
+provider "polaris" {
+	credentials = "{{ .Provider.Credentials }}"
+}
+
+data "polaris_data_center_archival_location" "test" {
+	cluster_id = "{{ .Resource.ClusterUUID }}"
+	name       = "{{ .Resource.LocationName }}"
+}
+`
+
+func TestAccCDMDataCenterArchivalLocation(t *testing.T) {
+	config, dc, err := loadDataCenterTestConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dc.ArchivalLocations) == 0 {
+		t.Fatal("TEST_DATACENTER_FILE has no archival locations")
+	}
+
+	for _, loc := range dc.ArchivalLocations {
+		t.Run(loc.LocationName, func(t *testing.T) {
+			config.Resource = testDataCenterArchivalLocation{
+				ClusterUUID:          dc.ClusterUUID,
+				ClusterIP:            dc.ClusterIP,
+				testArchivalLocation: loc,
+			}
+
+			dataCenterArchivalLocation, err := makeTerraformConfig(config, dataCenterArchivalLocationTmpl)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			const ds = "data.polaris_data_center_archival_location.test"
+			resource.Test(t, resource.TestCase{
+				ProviderFactories: providerFactories,
+				Steps: []resource.TestStep{{
+					Config: dataCenterArchivalLocation,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(ds, "name", loc.LocationName),
+						resource.TestCheckResourceAttr(ds, "id", loc.LocationID),
+						resource.TestCheckResourceAttr(ds, "target_type", loc.LocationType),
+						resource.TestCheckResourceAttrSet(ds, "status"),
+						resource.TestCheckResourceAttrSet(ds, "cluster_name"),
+						resource.TestCheckResourceAttrSet(ds, "cluster_status"),
+						resource.TestCheckResourceAttrSet(ds, "cluster_version"),
+					),
+				}},
+			})
+		})
+	}
+}


### PR DESCRIPTION
# Description

Add CDM-tagged acceptance tests for the data center archival location data source, along with shared canary and fixture helpers. Document the new `cdm` build tag and `TEST_DATACENTER_FILE` requirement in CLAUDE.md.

## How Has This Been Tested?

Manually against a RSC instance with connected and configured CDM cluster.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
