### PR TITLE
Update Rubrik Polaris SDK for Go to v1.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.22.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.5.1-0.20260422113418-c1e5b1a16f40
+	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.6.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.5.1-0.20260422113418-c1e5b1a16f40 h1:MVd9KQV1TWE3lQFbLeJ6DbymqRm0+TVtHXkXLbRrvHs=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.5.1-0.20260422113418-c1e5b1a16f40/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.6.0 h1:Dm2SsOyl1ClhKQoImkRJnZt2W12xIc8tp55xByReRpA=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.6.0/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=


### PR DESCRIPTION
# Description

Bumps ``github.com/rubrikinc/rubrik-polaris-sdk-for-go`` from a pseudo-version on the env-aliases branch to the tagged release ``v1.6.0``.

## Related Issue

N/A.

## Motivation and Context

Pins the SDK dependency to a proper semver tag for the v1.7.0 release. The pseudo-version was fine during development but the provider needs a stable tagged dependency before cutting v1.7.0.

## How Has This Been Tested?

```shell
go build ./...
go vet ./...
go test ./...
```
Both pass clean.

## Types of changes

What types of changes does your code introduce? Put an \`x\` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an \`x\` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.