### PR TITLE
Add support for AWS RECOVERY permission group on RDS and DynamoDB

### DIFF
--- a/docs/data-sources/aws_cnp_artifacts.md
+++ b/docs/data-sources/aws_cnp_artifacts.md
@@ -183,4 +183,4 @@ data "polaris_aws_cnp_artifacts" "artifacts" {
 Required:
 
 - `name` (String) RSC feature name. Possible values are `CLOUD_DISCOVERY`, `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_DYNAMODB_PROTECTION`, `CLOUD_NATIVE_PROTECTION`, `CLOUD_NATIVE_S3_PROTECTION`, `EXOCOMPUTE`, `KUBERNETES_PROTECTION`, `RDS_PROTECTION`, `ROLE_CHAINING` and `SERVERS_AND_APPS`.
-- `permission_groups` (Set of String) RSC permission groups for the feature. Possible values are `BASIC`, `CLOUD_CLUSTER_ES`, `DOWNLOAD_FILE`, `EXPORT_POWER_ON`, `EXPORT_POWER_OFF`, `RESTORE` and `RSC_MANAGED_CLUSTER`. For backwards compatibility, `[]` is interpreted as all applicable permission groups.
+- `permission_groups` (Set of String) RSC permission groups for the feature. Possible values are `BASIC`, `CLOUD_CLUSTER_ES`, `DOWNLOAD_FILE`, `EXPORT_POWER_ON`, `EXPORT_POWER_OFF`, `RECOVERY`, `RESTORE` and `RSC_MANAGED_CLUSTER`. For backwards compatibility, `[]` is interpreted as all applicable permission groups.

--- a/docs/data-sources/aws_cnp_permissions.md
+++ b/docs/data-sources/aws_cnp_permissions.md
@@ -25,6 +25,8 @@ are used when specifying the feature set.
 `CLOUD_NATIVE_DYNAMODB_PROTECTION`
   * `BASIC` - Represents the basic set of permissions required to onboard the
     feature.
+  * `RECOVERY` - Represents the set of elevated permissions required to perform
+    recovery operations.
 
 `CLOUD_NATIVE_S3_PROTECTION`
   * `BASIC` - Represents the basic set of permissions required to onboard the
@@ -43,6 +45,8 @@ are used when specifying the feature set.
 `RDS_PROTECTION`
   * `BASIC` - Represents the basic set of permissions required to onboard the
     feature.
+  * `RECOVERY` - Represents the set of elevated permissions required to perform
+    recovery operations.
 
 `ROLE_CHAINING`
   * `BASIC` - Represents the basic set of permissions required to onboard the
@@ -82,6 +86,8 @@ are used when specifying the feature set.
 `CLOUD_NATIVE_DYNAMODB_PROTECTION`
   * `BASIC` - Represents the basic set of permissions required to onboard the
     feature.
+  * `RECOVERY` - Represents the set of elevated permissions required to perform
+    recovery operations.
 
 `CLOUD_NATIVE_S3_PROTECTION`
   * `BASIC` - Represents the basic set of permissions required to onboard the
@@ -100,6 +106,8 @@ are used when specifying the feature set.
 `RDS_PROTECTION`
   * `BASIC` - Represents the basic set of permissions required to onboard the
     feature.
+  * `RECOVERY` - Represents the set of elevated permissions required to perform
+    recovery operations.
 
 `ROLE_CHAINING`
   * `BASIC` - Represents the basic set of permissions required to onboard the
@@ -175,7 +183,7 @@ data "polaris_aws_cnp_permissions" "permissions" {
 Required:
 
 - `name` (String) RSC feature name. Possible values are `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_PROTECTION`, `CLOUD_NATIVE_DYNAMODB_PROTECTION`, `CLOUD_NATIVE_S3_PROTECTION`, `KUBERNETES_PROTECTION`, `SERVERS_AND_APPS`, `EXOCOMPUTE` and `RDS_PROTECTION`.
-- `permission_groups` (Set of String) RSC permission groups for the feature. Possible values are `BASIC`, `CLOUD_CLUSTER_ES` and `RSC_MANAGED_CLUSTER`. For backwards compatibility, [] is interpreted as all applicable permission groups
+- `permission_groups` (Set of String) RSC permission groups for the feature. Possible values are `BASIC`, `CLOUD_CLUSTER_ES`, `DOWNLOAD_FILE`, `EXPORT_POWER_ON`, `EXPORT_POWER_OFF`, `RECOVERY`, `RESTORE` and `RSC_MANAGED_CLUSTER`. For backwards compatibility, [] is interpreted as all applicable permission groups.
 
 <a id="nestedatt--customer_managed_policies"></a>
 ### Nested Schema for `customer_managed_policies`

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -4,6 +4,17 @@ page_title: "Changelog"
 
 # Changelog
 
+## v1.8.0
+* **Breaking Change:** The `features` attribute on the `polaris_aws_cnp_account_attachments` resource has been
+  replaced with a `feature` block carrying both the feature name and its permission groups. State migrates
+  automatically; configurations must be updated. See the [upgrade guide](upgrade_guide_v1.8.0.md) for migration
+  instructions.
+* Add support for the `RECOVERY` permission group on the `RDS_PROTECTION` and `CLOUD_NATIVE_DYNAMODB_PROTECTION`
+  features in the `polaris_aws_account`, `polaris_aws_cnp_account` and `polaris_aws_cnp_account_attachments`
+  resources, and in the `polaris_aws_cnp_permissions` data source. Requires the
+  `REL_ENABLE_AWS_PAAS_DB_PRIVILEGE_ELEVATION` feature flag to be enabled on the RSC account.
+  [[docs](../resources/aws_cnp_account.md)] [[docs](../resources/aws_cnp_account_attachments.md)]
+
 ## v1.7.0
 * Add Terraform search support for the `polaris_custom_role` resource. Enables `terraform query` to discover custom
   roles in RSC, including roles not managed by Terraform.

--- a/docs/guides/upgrade_guide_v1.8.0.md
+++ b/docs/guides/upgrade_guide_v1.8.0.md
@@ -1,0 +1,143 @@
+---
+page_title: "Upgrade Guide: v1.8.0"
+---
+
+# Upgrade Guide v1.8.0
+
+## Before Upgrading
+
+Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
+provider.
+
+~> **Note:** If you are upgrading across multiple minor versions (e.g. v1.6.x to v1.8.0), review the upgrade guide for
+each intermediate version as well. Each guide documents breaking changes and migration steps specific to that release.
+
+## How to Upgrade
+
+Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.8.0 release. One
+way of doing this is by using the pessimistic constraint operator `~>`, which allows Terraform to upgrade to the latest
+release within the same minor version:
+```terraform
+terraform {
+  required_providers {
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "~> 1.8.0"
+    }
+  }
+}
+```
+Next, upgrade the provider to the new version by running:
+```shell
+% terraform init -upgrade
+```
+After the provider has been updated, validate the correctness of the Terraform configuration files by running:
+```shell
+% terraform plan
+```
+If you get an error or an unwanted diff, please see the _Breaking Changes_ and _New Features_ sections below for
+additional instructions. Otherwise, proceed by running:
+```shell
+% terraform apply -refresh-only
+```
+This will read the remote state of the resources and migrate the local Terraform state to the v1.8.0 version.
+
+## Breaking Changes
+
+### polaris_aws_cnp_account_attachments: feature schema reshape
+
+The `features` attribute on the `polaris_aws_cnp_account_attachments` resource has been replaced with a `feature`
+block that carries both the feature name and its permission groups. This lets the resource pass permission groups
+through to the RSC `registerAwsFeatureArtifacts` mutation, which is required for the new `RECOVERY` permission group on
+`RDS_PROTECTION` and `CLOUD_NATIVE_DYNAMODB_PROTECTION`.
+
+State is migrated automatically by a schema upgrader; the upgrader backfills `permission_groups = ["BASIC"]` for every
+existing feature, which matches the prior behavior. **You must update your configuration before running
+`terraform apply`** — otherwise Terraform will report the `features` attribute as removed.
+
+Before:
+```terraform
+resource "polaris_aws_cnp_account_attachments" "attachments" {
+  account_id = polaris_aws_cnp_account.account.id
+  features   = polaris_aws_cnp_account.account.feature.*.name
+
+  # ... instance_profile, role blocks ...
+}
+```
+
+After:
+```terraform
+resource "polaris_aws_cnp_account_attachments" "attachments" {
+  account_id = polaris_aws_cnp_account.account.id
+
+  dynamic "feature" {
+    for_each = polaris_aws_cnp_account.account.feature
+    content {
+      name              = feature.value["name"]
+      permission_groups = feature.value["permission_groups"]
+    }
+  }
+
+  # ... instance_profile, role blocks ...
+}
+```
+
+The `dynamic` block mirrors the feature/permission_group set already defined on the linked `polaris_aws_cnp_account`
+resource, so adding `RECOVERY` (or any new permission group) on the account propagates to the attachments resource
+without further changes.
+
+## New Features
+
+### AWS RDS and DynamoDB privilege elevation
+
+RSC has introduced a `RECOVERY` permission group for the `RDS_PROTECTION` and `CLOUD_NATIVE_DYNAMODB_PROTECTION`
+features. The `RECOVERY` group carries the elevated AWS privileges required to perform recovery operations on RDS
+instances and DynamoDB tables. Customers can now opt in to the elevated permissions only when recovery is needed,
+keeping the day-to-day footprint at `BASIC`.
+
+The new permission group is accepted on:
+- `polaris_aws_account` — `rds_protection.permission_groups` and `cloud_native_dynamodb_protection.permission_groups`
+- `polaris_aws_cnp_account` — `feature.permission_groups` when `feature.name` is `RDS_PROTECTION` or
+  `CLOUD_NATIVE_DYNAMODB_PROTECTION`
+- `polaris_aws_cnp_account_attachments` — `feature.permission_groups` for the same features
+- `polaris_aws_cnp_permissions` data source — request the recovery policy by setting
+  `feature.permission_groups = ["RECOVERY"]`
+
+`RECOVERY` requires the `REL_ENABLE_AWS_PAAS_DB_PRIVILEGE_ELEVATION` feature flag to be enabled on the RSC account.
+
+#### Example
+
+```terraform
+resource "polaris_aws_cnp_account" "account" {
+  # ... cloud, native_id, name, regions ...
+
+  feature {
+    name              = "RDS_PROTECTION"
+    permission_groups = ["BASIC", "RECOVERY"]
+  }
+
+  feature {
+    name              = "CLOUD_NATIVE_DYNAMODB_PROTECTION"
+    permission_groups = ["BASIC", "RECOVERY"]
+  }
+}
+```
+
+### Expected Terraform drift after RSC migrates existing accounts
+
+When the RSC backend migrates existing AWS accounts to the split permission groups, accounts that historically had
+`CLOUD_NATIVE_PROTECTION` `BASIC` will gain `RESTORE`, `EXPORT_POWER_ON`, `EXPORT_POWER_OFF` and `DOWNLOAD_FILE`. Other
+features (`RDS_PROTECTION`, `CLOUD_NATIVE_DYNAMODB_PROTECTION`) are not modified by the RSC migration — they remain at
+`BASIC` until the customer opts in to `RECOVERY`.
+
+After the RSC migration, a `terraform plan` against a configuration that lists only `BASIC` will show the new groups as
+being removed from the account. This is expected and not harmful — applying the plan removes the elevated permissions,
+returning the account to a `BASIC`-only footprint. To retain the elevated permissions, add them explicitly to the
+config:
+
+```terraform
+feature {
+  name              = "CLOUD_NATIVE_PROTECTION"
+  permission_groups = ["BASIC", "RESTORE", "EXPORT_POWER_ON", "EXPORT_POWER_OFF", "DOWNLOAD_FILE"]
+}
+```

--- a/docs/resources/aws_account.md
+++ b/docs/resources/aws_account.md
@@ -431,7 +431,7 @@ Read-Only:
 
 Required:
 
-- `permission_groups` (Set of String) Permission groups to assign to the feature. Possible values are `BASIC`.
+- `permission_groups` (Set of String) Permission groups to assign to the feature. Possible values are `BASIC`, `RECOVERY`.
 - `regions` (Set of String) Regions the feature will be enabled in.
 
 Read-Only:
@@ -561,7 +561,7 @@ Read-Only:
 
 Required:
 
-- `permission_groups` (Set of String) Permission groups to assign to the feature. Possible values are `BASIC`.
+- `permission_groups` (Set of String) Permission groups to assign to the feature. Possible values are `BASIC`, `RECOVERY`.
 - `regions` (Set of String) Regions the feature will be enabled in.
 
 Read-Only:

--- a/docs/resources/aws_cnp_account_attachments.md
+++ b/docs/resources/aws_cnp_account_attachments.md
@@ -5,17 +5,12 @@ subcategory: ""
 description: |-
   The aws_cnp_account_attachments resource attaches AWS instance profiles and AWS
   roles to an RSC cloud account.
-  -> Note: The features field takes only the feature names and not the permission
-  groups associated with the features.
 ---
 
 # polaris_aws_cnp_account_attachments (Resource)
 
 The `aws_cnp_account_attachments` resource attaches AWS instance profiles and AWS
 roles to an RSC cloud account.
-
--> **Note:** The `features` field takes only the feature names and not the permission
-   groups associated with the features.
 
 ## Example Usage
 
@@ -27,7 +22,14 @@ roles to an RSC cloud account.
 # and role has been defined for each RSC artifact.
 resource "polaris_aws_cnp_account_attachments" "attachments" {
   account_id = polaris_aws_cnp_account.account.id
-  features   = polaris_aws_cnp_account.account.feature.*.name
+
+  dynamic "feature" {
+    for_each = polaris_aws_cnp_account.account.feature
+    content {
+      name              = feature.value["name"]
+      permission_groups = feature.value["permission_groups"]
+    }
+  }
 
   dynamic "instance_profile" {
     for_each = aws_iam_instance_profile.profile
@@ -51,8 +53,15 @@ resource "polaris_aws_cnp_account_attachments" "attachments" {
 # the role-chaining account, use the above example.
 resource "polaris_aws_cnp_account_attachments" "attachments" {
   account_id               = polaris_aws_cnp_account.account.id
-  features                 = polaris_aws_cnp_account.account.feature.*.name
   role_chaining_account_id = polaris_aws_cnp_account.role_chaining.id
+
+  dynamic "feature" {
+    for_each = polaris_aws_cnp_account.account.feature
+    content {
+      name              = feature.value["name"]
+      permission_groups = feature.value["permission_groups"]
+    }
+  }
 
   dynamic "instance_profile" {
     for_each = aws_iam_instance_profile.profile
@@ -79,7 +88,7 @@ resource "polaris_aws_cnp_account_attachments" "attachments" {
 ### Required
 
 - `account_id` (String) RSC cloud account ID (UUID). Changing this forces a new resource to be created.
-- `features` (Set of String) RSC features. Possible values are `CLOUD_DISCOVERY`, `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_DYNAMODB_PROTECTION`, `CLOUD_NATIVE_PROTECTION`, `CLOUD_NATIVE_S3_PROTECTION`, `EXOCOMPUTE`, `KUBERNETES_PROTECTION`, `RDS_PROTECTION`, `ROLE_CHAINING` and `SERVERS_AND_APPS`.
+- `feature` (Block Set, Min: 1) RSC feature with permission groups. (see [below for nested schema](#nestedblock--feature))
 - `role` (Block Set, Min: 1) Roles to attach to the cloud account. (see [below for nested schema](#nestedblock--role))
 
 ### Optional
@@ -90,6 +99,15 @@ resource "polaris_aws_cnp_account_attachments" "attachments" {
 ### Read-Only
 
 - `id` (String) RSC cloud account ID (UUID).
+
+<a id="nestedblock--feature"></a>
+### Nested Schema for `feature`
+
+Required:
+
+- `name` (String) RSC feature name. Possible values are `CLOUD_DISCOVERY`, `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_DYNAMODB_PROTECTION`, `CLOUD_NATIVE_PROTECTION`, `CLOUD_NATIVE_S3_PROTECTION`, `EXOCOMPUTE`, `KUBERNETES_PROTECTION`, `RDS_PROTECTION`, `ROLE_CHAINING` and `SERVERS_AND_APPS`.
+- `permission_groups` (Set of String) RSC permission groups for the feature. Possible values are `BASIC`, `CLOUD_CLUSTER_ES`, `DOWNLOAD_FILE`, `EXPORT_POWER_ON`, `EXPORT_POWER_OFF`, `RECOVERY`, `RESTORE` and `RSC_MANAGED_CLUSTER`. For backwards compatibility, `[]` is interpreted as all applicable permission groups.
+
 
 <a id="nestedblock--role"></a>
 ### Nested Schema for `role`

--- a/examples/resources/polaris_aws_cnp_account_attachments/resource.tf
+++ b/examples/resources/polaris_aws_cnp_account_attachments/resource.tf
@@ -5,7 +5,14 @@
 # and role has been defined for each RSC artifact.
 resource "polaris_aws_cnp_account_attachments" "attachments" {
   account_id = polaris_aws_cnp_account.account.id
-  features   = polaris_aws_cnp_account.account.feature.*.name
+
+  dynamic "feature" {
+    for_each = polaris_aws_cnp_account.account.feature
+    content {
+      name              = feature.value["name"]
+      permission_groups = feature.value["permission_groups"]
+    }
+  }
 
   dynamic "instance_profile" {
     for_each = aws_iam_instance_profile.profile
@@ -29,8 +36,15 @@ resource "polaris_aws_cnp_account_attachments" "attachments" {
 # the role-chaining account, use the above example.
 resource "polaris_aws_cnp_account_attachments" "attachments" {
   account_id               = polaris_aws_cnp_account.account.id
-  features                 = polaris_aws_cnp_account.account.feature.*.name
   role_chaining_account_id = polaris_aws_cnp_account.role_chaining.id
+
+  dynamic "feature" {
+    for_each = polaris_aws_cnp_account.account.feature
+    content {
+      name              = feature.value["name"]
+      permission_groups = feature.value["permission_groups"]
+    }
+  }
 
   dynamic "instance_profile" {
     for_each = aws_iam_instance_profile.profile

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.22.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.6.0
+	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.6.1-0.20260518121356-748bf414e230
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.6.0 h1:Dm2SsOyl1ClhKQoImkRJnZt2W12xIc8tp55xByReRpA=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.6.0/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.6.1-0.20260518121356-748bf414e230 h1:nhCNxXlE/NtKhwfzmiP6sBbGibBcWSZdDgs9hl9d5i8=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.6.1-0.20260518121356-748bf414e230/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/internal/provider/data_source_aws_cnp_permissions.go
+++ b/internal/provider/data_source_aws_cnp_permissions.go
@@ -58,6 +58,8 @@ are used when specifying the feature set.
 ´CLOUD_NATIVE_DYNAMODB_PROTECTION´
   * ´BASIC´ - Represents the basic set of permissions required to onboard the
     feature.
+  * ´RECOVERY´ - Represents the set of elevated permissions required to perform
+    recovery operations.
 
 ´CLOUD_NATIVE_S3_PROTECTION´
   * ´BASIC´ - Represents the basic set of permissions required to onboard the
@@ -76,6 +78,8 @@ are used when specifying the feature set.
 ´RDS_PROTECTION´
   * ´BASIC´ - Represents the basic set of permissions required to onboard the
     feature.
+  * ´RECOVERY´ - Represents the set of elevated permissions required to perform
+    recovery operations.
 
 ´ROLE_CHAINING´
   * ´BASIC´ - Represents the basic set of permissions required to onboard the

--- a/internal/provider/resource_aws_account.go
+++ b/internal/provider/resource_aws_account.go
@@ -249,8 +249,11 @@ func resourceAwsAccount() *schema.Resource {
 				Description: "Enable the Cloud Native Protection feature for the account.",
 			},
 			keyCloudNativeDynamoDBProtection: {
-				Type:        schema.TypeList,
-				Elem:        awsCFTFeatureResource([]core.PermissionGroup{core.PermissionGroupBasic}),
+				Type: schema.TypeList,
+				Elem: awsCFTFeatureResource([]core.PermissionGroup{
+					core.PermissionGroupBasic,
+					core.PermissionGroupRecovery,
+				}),
 				MaxItems:    1,
 				Optional:    true,
 				Description: "Enable the Cloud Native DynamoDB Protection feature for the account.",
@@ -382,8 +385,11 @@ func resourceAwsAccount() *schema.Resource {
 				ValidateFunc: validation.StringIsNotWhiteSpace,
 			},
 			keyRDSProtection: {
-				Type:        schema.TypeList,
-				Elem:        awsCFTFeatureResource([]core.PermissionGroup{core.PermissionGroupBasic}),
+				Type: schema.TypeList,
+				Elem: awsCFTFeatureResource([]core.PermissionGroup{
+					core.PermissionGroupBasic,
+					core.PermissionGroupRecovery,
+				}),
 				MaxItems:    1,
 				Optional:    true,
 				Description: "Enable the RDS Protection feature for the account.",

--- a/internal/provider/resource_aws_cnp_account.go
+++ b/internal/provider/resource_aws_cnp_account.go
@@ -574,7 +574,7 @@ func featureResource() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
-						"BASIC", "RSC_MANAGED_CLUSTER", "CLOUD_CLUSTER_ES",
+						"BASIC", "RECOVERY", "RSC_MANAGED_CLUSTER", "CLOUD_CLUSTER_ES",
 						"EXPORT_POWER_ON", "EXPORT_POWER_OFF", "RESTORE", "DOWNLOAD_FILE",
 						// The following permission groups cannot be used when onboarding an AWS account.
 						// They have been accepted in the past so we still silently allow them.
@@ -584,7 +584,7 @@ func featureResource() *schema.Resource {
 				Required: true,
 				Description: "RSC permission groups for the feature. Possible values are `BASIC`, " +
 					"`CLOUD_CLUSTER_ES`, `DOWNLOAD_FILE`, `EXPORT_POWER_ON`, `EXPORT_POWER_OFF`, " +
-					"`RESTORE` and `RSC_MANAGED_CLUSTER`. For backwards compatibility, `[]` is " +
+					"`RECOVERY`, `RESTORE` and `RSC_MANAGED_CLUSTER`. For backwards compatibility, `[]` is " +
 					"interpreted as all applicable permission groups.",
 			},
 		},

--- a/internal/provider/resource_aws_cnp_account_attachments.go
+++ b/internal/provider/resource_aws_cnp_account_attachments.go
@@ -37,9 +37,6 @@ import (
 const resourceAWSCNPAccountAttachmentsDescription = `
 The ´aws_cnp_account_attachments´ resource attaches AWS instance profiles and AWS
 roles to an RSC cloud account.
-
--> **Note:** The ´features´ field takes only the feature names and not the permission
-   groups associated with the features.
 `
 
 func resourceAwsCnpAccountAttachments() *schema.Resource {
@@ -63,21 +60,12 @@ func resourceAwsCnpAccountAttachments() *schema.Resource {
 				Description:  "RSC cloud account ID (UUID). Changing this forces a new resource to be created.",
 				ValidateFunc: validation.IsUUID,
 			},
-			keyFeatures: {
-				Type: schema.TypeSet,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{
-						"CLOUD_DISCOVERY", "CLOUD_NATIVE_ARCHIVAL", "CLOUD_NATIVE_PROTECTION",
-						"CLOUD_NATIVE_S3_PROTECTION", "CLOUD_NATIVE_DYNAMODB_PROTECTION", "EXOCOMPUTE",
-						"RDS_PROTECTION", "KUBERNETES_PROTECTION", "SERVERS_AND_APPS", "ROLE_CHAINING",
-					}, false),
-				},
-				MinItems: 1,
-				Required: true,
-				Description: "RSC features. Possible values are `CLOUD_DISCOVERY`, `CLOUD_NATIVE_ARCHIVAL`, " +
-					"`CLOUD_NATIVE_DYNAMODB_PROTECTION`, `CLOUD_NATIVE_PROTECTION`, `CLOUD_NATIVE_S3_PROTECTION`, " +
-					"`EXOCOMPUTE`, `KUBERNETES_PROTECTION`, `RDS_PROTECTION`, `ROLE_CHAINING` and `SERVERS_AND_APPS`.",
+			keyFeature: {
+				Type:        schema.TypeSet,
+				Elem:        featureResource(),
+				MinItems:    1,
+				Required:    true,
+				Description: "RSC feature with permission groups.",
 			},
 			keyInstanceProfile: {
 				Type:        schema.TypeSet,
@@ -104,6 +92,13 @@ func resourceAwsCnpAccountAttachments() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
+
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{{
+			Type:    resourceAwsCnpAccountAttachmentsV0().CoreConfigSchema().ImpliedType(),
+			Upgrade: resourceAwsCnpAccountAttachmentsStateUpgradeV0,
+			Version: 0,
+		}},
 	}
 }
 
@@ -120,8 +115,13 @@ func awsCreateCnpAccountAttachments(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	var features []core.Feature
-	for _, feature := range d.Get(keyFeatures).(*schema.Set).List() {
-		features = append(features, core.Feature{Name: feature.(string)})
+	for _, block := range d.Get(keyFeature).(*schema.Set).List() {
+		block := block.(map[string]any)
+		feature := core.Feature{Name: block[keyName].(string)}
+		for _, group := range block[keyPermissionGroups].(*schema.Set).List() {
+			feature = feature.WithPermissionGroups(core.PermissionGroup(group.(string)))
+		}
+		features = append(features, feature)
 	}
 	profiles := make(map[string]string)
 	for _, roleAttr := range d.Get(keyInstanceProfile).(*schema.Set).List() {
@@ -182,9 +182,16 @@ func awsReadCnpAccountAttachments(ctx context.Context, d *schema.ResourceData, m
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	features := &schema.Set{F: schema.HashString}
+	featureSet := &schema.Set{F: schema.HashResource(featureResource())}
 	for _, feature := range account.Features {
-		features.Add(feature.Feature.Name)
+		groups := &schema.Set{F: schema.HashString}
+		for _, group := range feature.Feature.PermissionGroups {
+			groups.Add(string(group))
+		}
+		featureSet.Add(map[string]any{
+			keyName:             feature.Feature.Name,
+			keyPermissionGroups: groups,
+		})
 	}
 
 	// Request the cloud account artifacts.
@@ -196,7 +203,7 @@ func awsReadCnpAccountAttachments(ctx context.Context, d *schema.ResourceData, m
 	if err := d.Set(keyAccountID, account.ID.String()); err != nil {
 		return diag.FromErr(err)
 	}
-	if err := d.Set(keyFeatures, features); err != nil {
+	if err := d.Set(keyFeature, featureSet); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -244,8 +251,13 @@ func awsUpdateCnpAccountAttachments(ctx context.Context, d *schema.ResourceData,
 	}
 
 	var features []core.Feature
-	for _, feature := range d.Get(keyFeatures).(*schema.Set).List() {
-		features = append(features, core.Feature{Name: feature.(string)})
+	for _, block := range d.Get(keyFeature).(*schema.Set).List() {
+		block := block.(map[string]any)
+		feature := core.Feature{Name: block[keyName].(string)}
+		for _, group := range block[keyPermissionGroups].(*schema.Set).List() {
+			feature = feature.WithPermissionGroups(core.PermissionGroup(group.(string)))
+		}
+		features = append(features, feature)
 	}
 	profiles := make(map[string]string)
 	for _, roleAttr := range d.Get(keyInstanceProfile).(*schema.Set).List() {
@@ -320,8 +332,9 @@ func awsCustomizeDiffCnpAccountAttachments(ctx context.Context, diff *schema.Res
 	tflog.Trace(ctx, "awsCustomizeDiffCnpAccountAttachments")
 
 	var features []core.Feature
-	for _, feature := range diff.Get(keyFeatures).(*schema.Set).List() {
-		features = append(features, core.Feature{Name: feature.(string)})
+	for _, block := range diff.Get(keyFeature).(*schema.Set).List() {
+		block := block.(map[string]any)
+		features = append(features, core.Feature{Name: block[keyName].(string)})
 	}
 
 	return core.ValidateRoleChaining(features)

--- a/internal/provider/resource_aws_cnp_account_attachments_v0.go
+++ b/internal/provider/resource_aws_cnp_account_attachments_v0.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// resourceAwsCnpAccountAttachmentsV0 defines the schema for version 0 of the
+// AWS CNP account attachments resource, where features were a flat set of
+// feature name strings with no permission group association.
+func resourceAwsCnpAccountAttachmentsV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"account_id": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"features": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"instance_profile": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key":  {Type: schema.TypeString, Required: true},
+						"name": {Type: schema.TypeString, Required: true},
+					},
+				},
+			},
+			"role_chaining_account_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"role": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key":         {Type: schema.TypeString, Required: true},
+						"arn":         {Type: schema.TypeString, Required: true},
+						"permissions": {Type: schema.TypeString, Optional: true},
+					},
+				},
+			},
+		},
+	}
+}
+
+// resourceAwsCnpAccountAttachmentsStateUpgradeV0 converts the flat `features`
+// set into `feature` blocks carrying a permission_groups set. Existing v0
+// states only ever onboarded features at BASIC, so backfill BASIC for every
+// migrated feature.
+func resourceAwsCnpAccountAttachmentsStateUpgradeV0(ctx context.Context, state map[string]any, m any) (map[string]any, error) {
+	tflog.Trace(ctx, "resourceAwsCnpAccountAttachmentsStateUpgradeV0")
+
+	oldFeatures, _ := state["features"].([]any)
+	featureBlocks := make([]any, 0, len(oldFeatures))
+	for _, name := range oldFeatures {
+		featureBlocks = append(featureBlocks, map[string]any{
+			"name":              name,
+			"permission_groups": []any{"BASIC"},
+		})
+	}
+	state["feature"] = featureBlocks
+	delete(state, "features")
+
+	return state, nil
+}

--- a/internal/provider/resource_aws_cnp_account_attachments_v0.go
+++ b/internal/provider/resource_aws_cnp_account_attachments_v0.go
@@ -23,8 +23,11 @@ package provider
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/aws"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/core"
 )
 
 // resourceAwsCnpAccountAttachmentsV0 defines the schema for version 0 of the
@@ -33,43 +36,43 @@ import (
 func resourceAwsCnpAccountAttachmentsV0() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"id": {
+			keyID: {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"account_id": {
+			keyAccountID: {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"features": {
+			keyFeatures: {
 				Type:     schema.TypeSet,
 				Required: true,
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
 			},
-			"instance_profile": {
+			keyInstanceProfile: {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"key":  {Type: schema.TypeString, Required: true},
-						"name": {Type: schema.TypeString, Required: true},
+						keyKey:  {Type: schema.TypeString, Required: true},
+						keyName: {Type: schema.TypeString, Required: true},
 					},
 				},
 			},
-			"role_chaining_account_id": {
+			keyRoleChainingAccountID: {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"role": {
+			keyRole: {
 				Type:     schema.TypeSet,
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"key":         {Type: schema.TypeString, Required: true},
-						"arn":         {Type: schema.TypeString, Required: true},
-						"permissions": {Type: schema.TypeString, Optional: true},
+						keyKey:         {Type: schema.TypeString, Required: true},
+						keyARN:         {Type: schema.TypeString, Required: true},
+						keyPermissions: {Type: schema.TypeString, Optional: true},
 					},
 				},
 			},
@@ -78,22 +81,64 @@ func resourceAwsCnpAccountAttachmentsV0() *schema.Resource {
 }
 
 // resourceAwsCnpAccountAttachmentsStateUpgradeV0 converts the flat `features`
-// set into `feature` blocks carrying a permission_groups set. Existing v0
-// states only ever onboarded features at BASIC, so backfill BASIC for every
-// migrated feature.
+// set into `feature` blocks carrying a permission_groups set. For each feature
+// in v0 state, the live RSC account is consulted to populate the actual
+// permission groups currently registered — this avoids guessing a single
+// default (e.g. BASIC) that wouldn't be correct for features like EXOCOMPUTE
+// (BASIC + RSC_MANAGED_CLUSTER), SERVERS_AND_APPS (CLOUD_CLUSTER_ES, no BASIC)
+// or migrated CLOUD_NATIVE_PROTECTION (BASIC + RESTORE + EXPORT_POWER_ON +
+// EXPORT_POWER_OFF + DOWNLOAD_FILE). When a feature in v0 state is not present
+// on the account (drift), BASIC is used as a conservative fallback that the
+// next `terraform plan` will reconcile.
 func resourceAwsCnpAccountAttachmentsStateUpgradeV0(ctx context.Context, state map[string]any, m any) (map[string]any, error) {
 	tflog.Trace(ctx, "resourceAwsCnpAccountAttachmentsStateUpgradeV0")
 
-	oldFeatures, _ := state["features"].([]any)
+	client, err := m.(*client).polaris()
+	if err != nil {
+		return nil, err
+	}
+
+	id, err := uuid.Parse(state[keyID].(string))
+	if err != nil {
+		return nil, err
+	}
+
+	account, err := aws.Wrap(client).AccountByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	oldFeatures, _ := state[keyFeatures].([]any)
 	featureBlocks := make([]any, 0, len(oldFeatures))
-	for _, name := range oldFeatures {
+	for _, raw := range oldFeatures {
+		name := raw.(string)
+		groups := permissionGroupsFromAccount(account, name)
 		featureBlocks = append(featureBlocks, map[string]any{
-			"name":              name,
-			"permission_groups": []any{"BASIC"},
+			keyName:             name,
+			keyPermissionGroups: groups,
 		})
 	}
-	state["feature"] = featureBlocks
-	delete(state, "features")
+	state[keyFeature] = featureBlocks
+	delete(state, keyFeatures)
 
 	return state, nil
+}
+
+// permissionGroupsFromAccount returns the permission group names currently
+// registered for the named feature on the given account, or ["BASIC"] when the
+// feature is not present (drift fallback).
+func permissionGroupsFromAccount(account aws.CloudAccount, name string) []any {
+	for _, f := range account.Features {
+		if f.Feature.Name == name {
+			groups := make([]any, 0, len(f.PermissionGroups))
+			for _, g := range f.PermissionGroups {
+				groups = append(groups, string(g))
+			}
+			if len(groups) == 0 {
+				groups = append(groups, string(core.PermissionGroupBasic))
+			}
+			return groups
+		}
+	}
+	return []any{string(core.PermissionGroupBasic)}
 }

--- a/templates/data-sources/aws_cnp_permissions.md.tmpl
+++ b/templates/data-sources/aws_cnp_permissions.md.tmpl
@@ -39,7 +39,7 @@ description: |-
 Required:
 
 - `name` (String) RSC feature name. Possible values are `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_PROTECTION`, `CLOUD_NATIVE_DYNAMODB_PROTECTION`, `CLOUD_NATIVE_S3_PROTECTION`, `KUBERNETES_PROTECTION`, `SERVERS_AND_APPS`, `EXOCOMPUTE` and `RDS_PROTECTION`.
-- `permission_groups` (Set of String) RSC permission groups for the feature. Possible values are `BASIC`, `CLOUD_CLUSTER_ES` and `RSC_MANAGED_CLUSTER`. For backwards compatibility, [] is interpreted as all applicable permission groups
+- `permission_groups` (Set of String) RSC permission groups for the feature. Possible values are `BASIC`, `CLOUD_CLUSTER_ES`, `DOWNLOAD_FILE`, `EXPORT_POWER_ON`, `EXPORT_POWER_OFF`, `RECOVERY`, `RESTORE` and `RSC_MANAGED_CLUSTER`. For backwards compatibility, [] is interpreted as all applicable permission groups.
 
 <a id="nestedatt--customer_managed_policies"></a>
 ### Nested Schema for `customer_managed_policies`

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -4,6 +4,17 @@ page_title: "Changelog"
 
 # Changelog
 
+## v1.8.0
+* **Breaking Change:** The `features` attribute on the `polaris_aws_cnp_account_attachments` resource has been
+  replaced with a `feature` block carrying both the feature name and its permission groups. State migrates
+  automatically; configurations must be updated. See the [upgrade guide](upgrade_guide_v1.8.0.md) for migration
+  instructions.
+* Add support for the `RECOVERY` permission group on the `RDS_PROTECTION` and `CLOUD_NATIVE_DYNAMODB_PROTECTION`
+  features in the `polaris_aws_account`, `polaris_aws_cnp_account` and `polaris_aws_cnp_account_attachments`
+  resources, and in the `polaris_aws_cnp_permissions` data source. Requires the
+  `REL_ENABLE_AWS_PAAS_DB_PRIVILEGE_ELEVATION` feature flag to be enabled on the RSC account.
+  [[docs](../resources/aws_cnp_account.md)] [[docs](../resources/aws_cnp_account_attachments.md)]
+
 ## v1.7.0
 * Add Terraform search support for the `polaris_custom_role` resource. Enables `terraform query` to discover custom
   roles in RSC, including roles not managed by Terraform.

--- a/templates/guides/upgrade_guide_v1.8.0.md.tmpl
+++ b/templates/guides/upgrade_guide_v1.8.0.md.tmpl
@@ -1,0 +1,143 @@
+---
+page_title: "Upgrade Guide: v1.8.0"
+---
+
+# Upgrade Guide v1.8.0
+
+## Before Upgrading
+
+Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
+provider.
+
+~> **Note:** If you are upgrading across multiple minor versions (e.g. v1.6.x to v1.8.0), review the upgrade guide for
+each intermediate version as well. Each guide documents breaking changes and migration steps specific to that release.
+
+## How to Upgrade
+
+Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.8.0 release. One
+way of doing this is by using the pessimistic constraint operator `~>`, which allows Terraform to upgrade to the latest
+release within the same minor version:
+```terraform
+terraform {
+  required_providers {
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "~> 1.8.0"
+    }
+  }
+}
+```
+Next, upgrade the provider to the new version by running:
+```shell
+% terraform init -upgrade
+```
+After the provider has been updated, validate the correctness of the Terraform configuration files by running:
+```shell
+% terraform plan
+```
+If you get an error or an unwanted diff, please see the _Breaking Changes_ and _New Features_ sections below for
+additional instructions. Otherwise, proceed by running:
+```shell
+% terraform apply -refresh-only
+```
+This will read the remote state of the resources and migrate the local Terraform state to the v1.8.0 version.
+
+## Breaking Changes
+
+### polaris_aws_cnp_account_attachments: feature schema reshape
+
+The `features` attribute on the `polaris_aws_cnp_account_attachments` resource has been replaced with a `feature`
+block that carries both the feature name and its permission groups. This lets the resource pass permission groups
+through to the RSC `registerAwsFeatureArtifacts` mutation, which is required for the new `RECOVERY` permission group on
+`RDS_PROTECTION` and `CLOUD_NATIVE_DYNAMODB_PROTECTION`.
+
+State is migrated automatically by a schema upgrader; the upgrader backfills `permission_groups = ["BASIC"]` for every
+existing feature, which matches the prior behavior. **You must update your configuration before running
+`terraform apply`** — otherwise Terraform will report the `features` attribute as removed.
+
+Before:
+```terraform
+resource "polaris_aws_cnp_account_attachments" "attachments" {
+  account_id = polaris_aws_cnp_account.account.id
+  features   = polaris_aws_cnp_account.account.feature.*.name
+
+  # ... instance_profile, role blocks ...
+}
+```
+
+After:
+```terraform
+resource "polaris_aws_cnp_account_attachments" "attachments" {
+  account_id = polaris_aws_cnp_account.account.id
+
+  dynamic "feature" {
+    for_each = polaris_aws_cnp_account.account.feature
+    content {
+      name              = feature.value["name"]
+      permission_groups = feature.value["permission_groups"]
+    }
+  }
+
+  # ... instance_profile, role blocks ...
+}
+```
+
+The `dynamic` block mirrors the feature/permission_group set already defined on the linked `polaris_aws_cnp_account`
+resource, so adding `RECOVERY` (or any new permission group) on the account propagates to the attachments resource
+without further changes.
+
+## New Features
+
+### AWS RDS and DynamoDB privilege elevation
+
+RSC has introduced a `RECOVERY` permission group for the `RDS_PROTECTION` and `CLOUD_NATIVE_DYNAMODB_PROTECTION`
+features. The `RECOVERY` group carries the elevated AWS privileges required to perform recovery operations on RDS
+instances and DynamoDB tables. Customers can now opt in to the elevated permissions only when recovery is needed,
+keeping the day-to-day footprint at `BASIC`.
+
+The new permission group is accepted on:
+- `polaris_aws_account` — `rds_protection.permission_groups` and `cloud_native_dynamodb_protection.permission_groups`
+- `polaris_aws_cnp_account` — `feature.permission_groups` when `feature.name` is `RDS_PROTECTION` or
+  `CLOUD_NATIVE_DYNAMODB_PROTECTION`
+- `polaris_aws_cnp_account_attachments` — `feature.permission_groups` for the same features
+- `polaris_aws_cnp_permissions` data source — request the recovery policy by setting
+  `feature.permission_groups = ["RECOVERY"]`
+
+`RECOVERY` requires the `REL_ENABLE_AWS_PAAS_DB_PRIVILEGE_ELEVATION` feature flag to be enabled on the RSC account.
+
+#### Example
+
+```terraform
+resource "polaris_aws_cnp_account" "account" {
+  # ... cloud, native_id, name, regions ...
+
+  feature {
+    name              = "RDS_PROTECTION"
+    permission_groups = ["BASIC", "RECOVERY"]
+  }
+
+  feature {
+    name              = "CLOUD_NATIVE_DYNAMODB_PROTECTION"
+    permission_groups = ["BASIC", "RECOVERY"]
+  }
+}
+```
+
+### Expected Terraform drift after RSC migrates existing accounts
+
+When the RSC backend migrates existing AWS accounts to the split permission groups, accounts that historically had
+`CLOUD_NATIVE_PROTECTION` `BASIC` will gain `RESTORE`, `EXPORT_POWER_ON`, `EXPORT_POWER_OFF` and `DOWNLOAD_FILE`. Other
+features (`RDS_PROTECTION`, `CLOUD_NATIVE_DYNAMODB_PROTECTION`) are not modified by the RSC migration — they remain at
+`BASIC` until the customer opts in to `RECOVERY`.
+
+After the RSC migration, a `terraform plan` against a configuration that lists only `BASIC` will show the new groups as
+being removed from the account. This is expected and not harmful — applying the plan removes the elevated permissions,
+returning the account to a `BASIC`-only footprint. To retain the elevated permissions, add them explicitly to the
+config:
+
+```terraform
+feature {
+  name              = "CLOUD_NATIVE_PROTECTION"
+  permission_groups = ["BASIC", "RESTORE", "EXPORT_POWER_ON", "EXPORT_POWER_OFF", "DOWNLOAD_FILE"]
+}
+```


### PR DESCRIPTION
# Description

Surface the new `RECOVERY` permission group that RSC introduced for the `RDS_PROTECTION` and `CLOUD_NATIVE_DYNAMODB_PROTECTION` features. `RECOVERY` carries the elevated AWS privileges required to perform recovery operations on RDS instances and DynamoDB tables and can be enabled independently of `BASIC`. Customers can now opt in to the elevated permissions only when recovery is needed, keeping the day-to-day footprint at `BASIC`.

Affected resources:
- `polaris_aws_account`: `rds_protection.permission_groups` and `cloud_native_dynamodb_protection.permission_groups` now accept `RECOVERY`.
- `polaris_aws_cnp_account`: `feature.permission_groups` validator now accepts `RECOVERY`.
- `polaris_aws_cnp_account_attachments`: `features` (flat string set) replaced with a `feature` block carrying `name` + `permission_groups`, mirroring `polaris_aws_cnp_account`. A v0 to v1 state upgrader queries the live RSC account during migration to populate `permission_groups` from what's actually registered (handles non-`BASIC` defaults like `SERVERS_AND_APPS = [CLOUD_CLUSTER_ES]` and post-migration `CLOUD_NATIVE_PROTECTION = [BASIC, RESTORE, EXPORT_POWER_ON, EXPORT_POWER_OFF, DOWNLOAD_FILE]`).
- `polaris_aws_cnp_permissions`: data source descriptions updated.

## Motivation and Context

RSC backend rollout of permission grouping for AWS PaaS DB features. The `featuresWithPermissionsGroups` field on `AwsAccountFeatureArtifact` became available in the schema in late December 2025. Without the schema reshape on `polaris_aws_cnp_account_attachments`, attachments would silently fail to carry the permission group choices through to `registerAwsFeatureArtifacts` — the backend treats that field as authoritative when granular permissions are enabled and would deboard groups the account had set.

Requires the `REL_ENABLE_AWS_PAAS_DB_PRIVILEGE_ELEVATION` feature flag enabled on the RSC account for `RECOVERY` to take effect. With the flag off, the backend silently drops `RECOVERY` from the request, which would produce a perpetual diff — the upgrade guide notes this.

Depends on a matching SDK change (PR pending) that exposes `FeaturesWithPermissionsGroups` on `AccountFeatureArtifact`. The provider is currently pinned to commit `748bf41` on `draper_aws_permission_groups_artifacts`; will be re-pinned to a tagged SDK release before merging.

## How Has This Been Tested?

- `go build`, `go vet`, `gofmt`: clean.
- `go generate ./...`: regenerated docs reflect the new `feature` block on `polaris_aws_cnp_account_attachments` and `RECOVERY` on the relevant validators.
- `go test ./...`: non-acceptance unit tests pass; acceptance tests gated on `TF_ACC=1` + RSC credentials (no behavior regressions observed locally).
- Manual end-to-end on a live RSC env (`tf-test-draper`,) with `REL_ENABLE_AWS_PAAS_DB_PRIVILEGE_ELEVATION` enabled:
  - `polaris_aws_cnp_account` with `feature { name = "RDS_PROTECTION"; permission_groups = ["BASIC", "RECOVERY"] }` and `CLOUD_NATIVE_DYNAMODB_PROTECTION` applies cleanly.
  - Backend round-trip confirmed via `featureDetails`: `RDS_PROTECTION` and `CLOUD_NATIVE_DYNAMODB_PROTECTION` both report `[BASIC, RECOVERY]`, `CLOUD_NATIVE_PROTECTION` reports the full `[BASIC, EXPORT_POWER_ON, EXPORT_POWER_OFF, RESTORE, DOWNLOAD_FILE]`, `SERVERS_AND_APPS` reports `[CLOUD_CLUSTER_ES]` (no `BASIC`, as expected), `EXOCOMPUTE` reports `[BASIC, RSC_MANAGED_CLUSTER]`.
  - v0 to v1 state migration exercised by upgrading the provider against an existing flat-`features` state — upgrader successfully queried the account and populated correct per-feature permission groups; subsequent plan is clean once the HCL is converted to the `dynamic "feature"` form documented in the upgrade guide.

## Types of changes

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (`polaris_aws_cnp_account_attachments.features` flat set replaced with `feature` block — state migrates automatically, but HCL must be updated)

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly (`templates/guides/upgrade_guide_v1.8.0.md.tmpl`, `templates/guides/changelog.md.tmpl`, `examples/resources/polaris_aws_cnp_account_attachments/resource.tf`).
- [ ] I have added tests to cover my changes. (Acceptance test coverage for this area is sparse; manual end-to-end testing performed.)
- [x] All new and existing tests passed.

## Notes for reviewers

- Branch off `main`. The v1.8.0 upgrade guide / changelog entries will conflict with the multi-AZ branch (`draper_cces_multi_az`); the conflict is mechanical (combine the new sections under the same v1.8.0 heading).
- `go.mod` currently pins the SDK to a commit hash on `draper_aws_permission_groups_artifacts`; this will be replaced with a tagged release before merge.
- The `dynamic "feature"` pattern in the upgrade guide is not just stylistic — attachments now becomes a co-author of the account's permission-group state, so mirroring the account is required to avoid silently deboarding groups.