### PR TITLE
Update v1.8.0 Changelog ordering

### DIFF
--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -8,6 +8,11 @@ page_title: "Changelog"
 * Add support for the `AzureNativeResourceGroup` object type in the `polaris_object` data source. Pair with the
   new `subscription_id` field to resolve an Azure resource group to its RSC ID by `(subscription_id, name)`.
   [[docs](../data-sources/object.md)]
+* New data source added for `polaris_aws_permission_groups` which returns the permission groups available for a
+  single RSC AWS feature, along with the IAM action statements that each permission group requires. Useful for
+  programmatically discovering the available permission groups (for example, the `BASIC` and `RECOVERY` split on
+  `RDS_PROTECTION`) at plan time.
+  [[docs](../data-sources/aws_permission_groups.md)]
 * New data source added for `polaris_azure_permission_groups` which returns the permission groups available for a
   single RSC Azure feature, along with the Azure RBAC actions and data actions each permission group requires.
   Statements are tagged with their scope (`subscription` or `resource_group`) and kind (`action` or
@@ -17,15 +22,16 @@ page_title: "Changelog"
   The new `az_resilient` field enables deploying clusters across multiple availability zones, and the new
   `subnet_az_config` block in `vm_config` specifies per-zone subnet mappings.
   [[docs](../resources/aws_cloud_cluster.md)] [[docs](../resources/azure_cloud_cluster.md)]
+* Add write-only attributes for `admin_email` and `admin_password` in the `cluster_config` block of the
+  `polaris_aws_cloud_cluster` and `polaris_azure_cloud_cluster` resources. The credentials are only consumed during
+  initial cluster creation and are no longer persisted to state. Requires Terraform v1.11.0 or later.
+  [[docs](../resources/aws_cloud_cluster.md)] [[docs](../resources/azure_cloud_cluster.md)]
 
 ## v1.7.1
 * **Deprecated:** `features` field in the `polaris_aws_cnp_account_attachments` resource. Permission groups for each
   feature are now read from the cloud account managed by `polaris_aws_cnp_account` when artifacts are registered, so
   this field no longer needs to track them. The field is retained for backwards compatibility and will be removed in
   a future major release. See the [v1.7.1 upgrade guide](upgrade_guide_v1.7.1.md).
-* New data source added for `polaris_aws_permission_groups` which retrieves the latest permission groups, and the
-  underlying IAM action statements, available for one or more RSC AWS features.
-  [[docs](../data-sources/aws_permission_groups.md)]
 * Add support for the `RECOVERY` permission group in the `RDS_PROTECTION` and `CLOUD_NATIVE_DYNAMODB_PROTECTION`
   features in the `polaris_aws_account`, `polaris_aws_cnp_account` and `polaris_aws_cnp_account_attachments`
   resources. `RECOVERY` grants the elevated AWS permissions required to perform recovery operations.

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -8,6 +8,11 @@ page_title: "Changelog"
 * Add support for the `AzureNativeResourceGroup` object type in the `polaris_object` data source. Pair with the
   new `subscription_id` field to resolve an Azure resource group to its RSC ID by `(subscription_id, name)`.
   [[docs](../data-sources/object.md)]
+* New data source added for `polaris_aws_permission_groups` which returns the permission groups available for a
+  single RSC AWS feature, along with the IAM action statements that each permission group requires. Useful for
+  programmatically discovering the available permission groups (for example, the `BASIC` and `RECOVERY` split on
+  `RDS_PROTECTION`) at plan time.
+  [[docs](../data-sources/aws_permission_groups.md)]
 * New data source added for `polaris_azure_permission_groups` which returns the permission groups available for a
   single RSC Azure feature, along with the Azure RBAC actions and data actions each permission group requires.
   Statements are tagged with their scope (`subscription` or `resource_group`) and kind (`action` or
@@ -17,15 +22,16 @@ page_title: "Changelog"
   The new `az_resilient` field enables deploying clusters across multiple availability zones, and the new
   `subnet_az_config` block in `vm_config` specifies per-zone subnet mappings.
   [[docs](../resources/aws_cloud_cluster.md)] [[docs](../resources/azure_cloud_cluster.md)]
+* Add write-only attributes for `admin_email` and `admin_password` in the `cluster_config` block of the
+  `polaris_aws_cloud_cluster` and `polaris_azure_cloud_cluster` resources. The credentials are only consumed during
+  initial cluster creation and are no longer persisted to state. Requires Terraform v1.11.0 or later.
+  [[docs](../resources/aws_cloud_cluster.md)] [[docs](../resources/azure_cloud_cluster.md)]
 
 ## v1.7.1
 * **Deprecated:** `features` field in the `polaris_aws_cnp_account_attachments` resource. Permission groups for each
   feature are now read from the cloud account managed by `polaris_aws_cnp_account` when artifacts are registered, so
   this field no longer needs to track them. The field is retained for backwards compatibility and will be removed in
   a future major release. See the [v1.7.1 upgrade guide](upgrade_guide_v1.7.1.md).
-* New data source added for `polaris_aws_permission_groups` which retrieves the latest permission groups, and the
-  underlying IAM action statements, available for one or more RSC AWS features.
-  [[docs](../data-sources/aws_permission_groups.md)]
 * Add support for the `RECOVERY` permission group in the `RDS_PROTECTION` and `CLOUD_NATIVE_DYNAMODB_PROTECTION`
   features in the `polaris_aws_account`, `polaris_aws_cnp_account` and `polaris_aws_cnp_account_attachments`
   resources. `RECOVERY` grants the elevated AWS permissions required to perform recovery operations.


### PR DESCRIPTION
# Description

- Move the polaris_aws_permission_groups data source entry from v1.7.1 to v1.8.0 and reword it to match the rubrik provider and the data source's actual single-feature behavior. It was added after the v1.7.1 tag (commit 3fabc36, #447) and was not part of the v1.7.1 release.
- Add a changelog entry for the now write-only admin_email/admin_password attributes on polaris_aws_cloud_cluster and polaris_azure_cloud_cluster (require Terraform v1.11.0), matching the rubrik provider's wording and the v1.8.0 upgrade guide.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
