### PR TITLE
Add support for SERVERS_AND_APPS feature in GCP project

### DIFF
--- a/docs/data-sources/gcp_permissions.md
+++ b/docs/data-sources/gcp_permissions.md
@@ -30,8 +30,12 @@ description: |-
   for automated networking setup. When automated networking setup is enabled,
   RSC is responsible for creating and maintaining the networking resources for
   Exocompute. See the polaris_gcp_exocompute resource for more information.
+  SERVERS_AND_APPS
+  CLOUD_CLUSTER_ES - Represents the set of permissions required to onboard
+  the feature.
   -> Note: When permission groups are specified, the BASIC permission group
-  is always required .
+  is always required, except for SERVERS_AND_APPS which only supports the
+  CLOUD_CLUSTER_ES permission group and does not use BASIC.
   -> Note: Due to backward compatibility, the features field allow the
   feature names to be given in 3 different styles: EXAMPLE_FEATURE_NAME,
   example-feature-name or example_feature_name. The recommended style is
@@ -78,8 +82,13 @@ are used when specifying the feature.
     RSC is responsible for creating and maintaining the networking resources for
     Exocompute. See the `polaris_gcp_exocompute` resource for more information.
 
+`SERVERS_AND_APPS`
+  * `CLOUD_CLUSTER_ES` - Represents the set of permissions required to onboard
+    the feature.
+
 -> **Note:** When permission groups are specified, the `BASIC` permission group
-   is always required .
+   is always required, except for `SERVERS_AND_APPS` which only supports the
+   `CLOUD_CLUSTER_ES` permission group and does not use `BASIC`.
 
 -> **Note:** Due to backward compatibility, the `features` field allow the
    feature names to be given in 3 different styles: `EXAMPLE_FEATURE_NAME`,
@@ -103,9 +112,9 @@ data "polaris_gcp_permissions" "cloud_native_archival" {
 
 ### Optional
 
-- `feature` (String) RSC feature. Note that the feature must be given in the `EXAMPLE_FEATURE_NAME` style. Possible values are `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_PROTECTION`, `GCP_SHARED_VPC_HOST` and `EXOCOMPUTE`.
-- `features` (Set of String, Deprecated) RSC features. Possible values are `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_PROTECTION`, `GCP_SHARED_VPC_HOST` and `EXOCOMPUTE`. **Deprecated:** use `feature` instead.
-- `permission_groups` (Set of String) Permission groups for the RSC feature. Possible values are `BASIC`, `ENCRYPTION`, `EXPORT_AND_RESTORE`, `FILE_LEVEL_RECOVERY` and `AUTOMATED_NETWORKING_SETUP`.
+- `feature` (String) RSC feature. Note that the feature must be given in the `EXAMPLE_FEATURE_NAME` style. Possible values are `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_PROTECTION`, `GCP_SHARED_VPC_HOST`, `EXOCOMPUTE` and `SERVERS_AND_APPS`.
+- `features` (Set of String, Deprecated) RSC features. Possible values are `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_PROTECTION`, `GCP_SHARED_VPC_HOST`, `EXOCOMPUTE` and `SERVERS_AND_APPS`. **Deprecated:** use `feature` instead.
+- `permission_groups` (Set of String) Permission groups for the RSC feature. Possible values are `BASIC`, `ENCRYPTION`, `EXPORT_AND_RESTORE`, `FILE_LEVEL_RECOVERY`, `AUTOMATED_NETWORKING_SETUP` and `CLOUD_CLUSTER_ES`.
 
 ### Read-Only
 

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -4,6 +4,12 @@ page_title: "Changelog"
 
 # Changelog
 
+## v1.9.0
+* Add support for the `SERVERS_AND_APPS` feature in the `polaris_gcp_project` resource and the `polaris_gcp_project`
+  and `polaris_gcp_permissions` data sources. The feature uses the `CLOUD_CLUSTER_ES` permission group and, unlike
+  other GCP features, does not use the `BASIC` permission group.
+  [[docs](../resources/gcp_project.md)]
+
 ## v1.8.0
 * Add support for the `AzureNativeResourceGroup` object type in the `polaris_object` data source. Pair with the
   new `subscription_id` field to resolve an Azure resource group to its RSC ID by `(subscription_id, name)`.

--- a/docs/resources/gcp_project.md
+++ b/docs/resources/gcp_project.md
@@ -28,6 +28,10 @@ description: |-
   for automated networking setup. When automated networking setup is enabled,
   RSC is responsible for creating and maintaining the networking resources for
   Exocompute. See the polaris_gcp_exocompute resource for more information.
+  SERVERS_AND_APPS
+  CLOUD_CLUSTER_ES - Represents the set of permissions required to onboard
+  the feature. Note, unlike other features, SERVERS_AND_APPS does not use
+  the BASIC permission group.
 ---
 
 # polaris_gcp_project (Resource)
@@ -67,6 +71,11 @@ are used when specifying the feature.
     for automated networking setup. When automated networking setup is enabled,
     RSC is responsible for creating and maintaining the networking resources for
     Exocompute. See the `polaris_gcp_exocompute` resource for more information.
+
+`SERVERS_AND_APPS`
+  * `CLOUD_CLUSTER_ES` - Represents the set of permissions required to onboard
+    the feature. Note, unlike other features, `SERVERS_AND_APPS` does not use
+    the `BASIC` permission group.
 
 ## Example Usage
 
@@ -130,8 +139,8 @@ Optional:
 
 Required:
 
-- `name` (String) RSC feature name. Possible values are `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_PROTECTION`, `GCP_SHARED_VPC_HOST` and `EXOCOMPUTE`.
-- `permission_groups` (Set of String) Permission groups for the RSC feature. Possible values are `BASIC`, `ENCRYPTION`, `EXPORT_AND_RESTORE`, `FILE_LEVEL_RECOVERY` and `AUTOMATED_NETWORKING_SETUP`.
+- `name` (String) RSC feature name. Possible values are `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_PROTECTION`, `GCP_SHARED_VPC_HOST`, `EXOCOMPUTE` and `SERVERS_AND_APPS`.
+- `permission_groups` (Set of String) Permission groups for the RSC feature. Possible values are `BASIC`, `ENCRYPTION`, `EXPORT_AND_RESTORE`, `FILE_LEVEL_RECOVERY`, `AUTOMATED_NETWORKING_SETUP` and `CLOUD_CLUSTER_ES`.
 
 Optional:
 

--- a/internal/provider/data_source_gcp_permissions.go
+++ b/internal/provider/data_source_gcp_permissions.go
@@ -74,8 +74,13 @@ are used when specifying the feature.
     RSC is responsible for creating and maintaining the networking resources for
     Exocompute. See the ´polaris_gcp_exocompute´ resource for more information.
 
+´SERVERS_AND_APPS´
+  * ´CLOUD_CLUSTER_ES´ - Represents the set of permissions required to onboard
+    the feature.
+
 -> **Note:** When permission groups are specified, the ´BASIC´ permission group
-   is always required .
+   is always required, except for ´SERVERS_AND_APPS´ which only supports the
+   ´CLOUD_CLUSTER_ES´ permission group and does not use ´BASIC´.
 
 -> **Note:** Due to backward compatibility, the ´features´ field allow the
    feature names to be given in 3 different styles: ´EXAMPLE_FEATURE_NAME´,
@@ -108,10 +113,11 @@ func dataSourceGcpPermissions() *schema.Resource {
 				Optional:     true,
 				ExactlyOneOf: []string{keyFeatures},
 				Description: "RSC feature. Note that the feature must be given in the `EXAMPLE_FEATURE_NAME` style. " +
-					"Possible values are `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_PROTECTION`, `GCP_SHARED_VPC_HOST` " +
-					"and `EXOCOMPUTE`.",
+					"Possible values are `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_PROTECTION`, `GCP_SHARED_VPC_HOST`, " +
+					"`EXOCOMPUTE` and `SERVERS_AND_APPS`.",
 				ValidateFunc: validation.StringInSlice([]string{
 					"CLOUD_NATIVE_ARCHIVAL", "CLOUD_NATIVE_PROTECTION", "GCP_SHARED_VPC_HOST", "EXOCOMPUTE",
+					"SERVERS_AND_APPS",
 				}, false),
 			},
 			keyFeatures: {
@@ -120,13 +126,14 @@ func dataSourceGcpPermissions() *schema.Resource {
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
 						"CLOUD_NATIVE_ARCHIVAL", "CLOUD_NATIVE_PROTECTION", "GCP_SHARED_VPC_HOST", "EXOCOMPUTE",
+						"SERVERS_AND_APPS",
 					}, false),
 				},
 				Optional:     true,
 				MinItems:     1,
 				ExactlyOneOf: []string{keyFeature},
 				Description: "RSC features. Possible values are `CLOUD_NATIVE_ARCHIVAL`, `CLOUD_NATIVE_PROTECTION`, " +
-					"`GCP_SHARED_VPC_HOST` and `EXOCOMPUTE`. **Deprecated:** use `feature` instead.",
+					"`GCP_SHARED_VPC_HOST`, `EXOCOMPUTE` and `SERVERS_AND_APPS`. **Deprecated:** use `feature` instead.",
 				Deprecated: "Use `feature` instead",
 			},
 			keyHash: {
@@ -142,14 +149,14 @@ func dataSourceGcpPermissions() *schema.Resource {
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
 						"BASIC", "ENCRYPTION", "EXPORT_AND_RESTORE", "FILE_LEVEL_RECOVERY",
-						"AUTOMATED_NETWORKING_SETUP",
+						"AUTOMATED_NETWORKING_SETUP", "CLOUD_CLUSTER_ES",
 					}, false),
 				},
 				Optional:      true,
 				ConflictsWith: []string{keyFeatures},
 				RequiredWith:  []string{keyFeature},
 				Description: "Permission groups for the RSC feature. Possible values are `BASIC`, `ENCRYPTION`, " +
-					"`EXPORT_AND_RESTORE`, `FILE_LEVEL_RECOVERY` and `AUTOMATED_NETWORKING_SETUP`.",
+					"`EXPORT_AND_RESTORE`, `FILE_LEVEL_RECOVERY`, `AUTOMATED_NETWORKING_SETUP` and `CLOUD_CLUSTER_ES`.",
 			},
 			keyPermissions: {
 				Type: schema.TypeList,

--- a/internal/provider/data_source_gcp_project.go
+++ b/internal/provider/data_source_gcp_project.go
@@ -171,9 +171,10 @@ func gcpFeatureResourceWithStatus() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				Description: "RSC feature name. Possible values are `CLOUD_NATIVE_ARCHIVAL`, " +
-					"`CLOUD_NATIVE_PROTECTION`, `GCP_SHARED_VPC_HOST` and `EXOCOMPUTE`.",
+					"`CLOUD_NATIVE_PROTECTION`, `GCP_SHARED_VPC_HOST`, `EXOCOMPUTE` and `SERVERS_AND_APPS`.",
 				ValidateFunc: validation.StringInSlice([]string{
 					"CLOUD_NATIVE_ARCHIVAL", "CLOUD_NATIVE_PROTECTION", "GCP_SHARED_VPC_HOST", "EXOCOMPUTE",
+					"SERVERS_AND_APPS",
 				}, false),
 			},
 			keyPermissionGroups: {
@@ -182,12 +183,12 @@ func gcpFeatureResourceWithStatus() *schema.Resource {
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
 						"BASIC", "ENCRYPTION", "EXPORT_AND_RESTORE", "FILE_LEVEL_RECOVERY",
-						"AUTOMATED_NETWORKING_SETUP",
+						"AUTOMATED_NETWORKING_SETUP", "CLOUD_CLUSTER_ES",
 					}, false),
 				},
 				Required: true,
 				Description: "Permission groups for the RSC feature. Possible values are `BASIC`, `ENCRYPTION`, " +
-					"`EXPORT_AND_RESTORE`, `FILE_LEVEL_RECOVERY` and `AUTOMATED_NETWORKING_SETUP`.",
+					"`EXPORT_AND_RESTORE`, `FILE_LEVEL_RECOVERY`, `AUTOMATED_NETWORKING_SETUP` and `CLOUD_CLUSTER_ES`.",
 			},
 			keyStatus: {
 				Type:        schema.TypeString,

--- a/internal/provider/resource_gcp_project.go
+++ b/internal/provider/resource_gcp_project.go
@@ -72,6 +72,11 @@ are used when specifying the feature.
     for automated networking setup. When automated networking setup is enabled,
     RSC is responsible for creating and maintaining the networking resources for
     Exocompute. See the ´polaris_gcp_exocompute´ resource for more information.
+
+´SERVERS_AND_APPS´
+  * ´CLOUD_CLUSTER_ES´ - Represents the set of permissions required to onboard
+    the feature. Note, unlike other features, ´SERVERS_AND_APPS´ does not use
+    the ´BASIC´ permission group.
 `
 
 func resourceGcpProject() *schema.Resource {
@@ -414,9 +419,10 @@ func gcpFeatureResourceWithPermissionsAndStatus() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				Description: "RSC feature name. Possible values are `CLOUD_NATIVE_ARCHIVAL`, " +
-					"`CLOUD_NATIVE_PROTECTION`, `GCP_SHARED_VPC_HOST` and `EXOCOMPUTE`.",
+					"`CLOUD_NATIVE_PROTECTION`, `GCP_SHARED_VPC_HOST`, `EXOCOMPUTE` and `SERVERS_AND_APPS`.",
 				ValidateFunc: validation.StringInSlice([]string{
 					"CLOUD_NATIVE_ARCHIVAL", "CLOUD_NATIVE_PROTECTION", "GCP_SHARED_VPC_HOST", "EXOCOMPUTE",
+					"SERVERS_AND_APPS",
 				}, false),
 			},
 			keyPermissionGroups: {
@@ -425,12 +431,12 @@ func gcpFeatureResourceWithPermissionsAndStatus() *schema.Resource {
 					Type: schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{
 						"BASIC", "ENCRYPTION", "EXPORT_AND_RESTORE", "FILE_LEVEL_RECOVERY",
-						"AUTOMATED_NETWORKING_SETUP",
+						"AUTOMATED_NETWORKING_SETUP", "CLOUD_CLUSTER_ES",
 					}, false),
 				},
 				Required: true,
 				Description: "Permission groups for the RSC feature. Possible values are `BASIC`, `ENCRYPTION`, " +
-					"`EXPORT_AND_RESTORE`, `FILE_LEVEL_RECOVERY` and `AUTOMATED_NETWORKING_SETUP`.",
+					"`EXPORT_AND_RESTORE`, `FILE_LEVEL_RECOVERY`, `AUTOMATED_NETWORKING_SETUP` and `CLOUD_CLUSTER_ES`.",
 			},
 			keyPermissions: {
 				Type:     schema.TypeString,

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -4,6 +4,12 @@ page_title: "Changelog"
 
 # Changelog
 
+## v1.9.0
+* Add support for the `SERVERS_AND_APPS` feature in the `polaris_gcp_project` resource and the `polaris_gcp_project`
+  and `polaris_gcp_permissions` data sources. The feature uses the `CLOUD_CLUSTER_ES` permission group and, unlike
+  other GCP features, does not use the `BASIC` permission group.
+  [[docs](../resources/gcp_project.md)]
+
 ## v1.8.0
 * Add support for the `AzureNativeResourceGroup` object type in the `polaris_object` data source. Pair with the
   new `subscription_id` field to resolve an Azure resource group to its RSC ID by `(subscription_id, name)`.


### PR DESCRIPTION
## Summary
Adds support for onboarding the `SERVERS_AND_APPS` feature for GCP projects via the `polaris_gcp_project` resource, and reading it back through the `polaris_gcp_project` and `polaris_gcp_permissions` data sources.

Unlike other GCP features, `SERVERS_AND_APPS` uses only the `CLOUD_CLUSTER_ES` permission group and does not use `BASIC`. Docs and the permissions data source note are updated accordingly.

## Testing
Built the provider locally and ran a full onboard of a GCP project with `SERVERS_AND_APPS` + `CLOUD_NATIVE_PROTECTION`, then tore it down. Both features settled to `connected`, and destroy removed all resources cleanly.

```
Apply complete! Resources: 12 added, 0 changed, 0 destroyed.

cloud_account_id = "<redacted>"
features = {
  "CLOUD_NATIVE_PROTECTION" = "connected"
  "SERVERS_AND_APPS"        = "connected"
}
```

```
Destroy complete! Resources: 12 destroyed.
```