### PR TITLE
Drop client-side ROLE_CHAINING workarounds in AWS CNP resources

### DIFF
--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -10,8 +10,9 @@ page_title: "Changelog"
   other GCP features, does not use the `BASIC` permission group.
   [[docs](../resources/gcp_project.md)]
 * Fix ROLE_CHAINING handling in the `polaris_aws_cnp_account` and `polaris_aws_cnp_account_attachments` resources and
-  the `polaris_aws_cnp_permissions` data source. The Go SDK now filters the spurious CROSSACCOUNT artifact RSC returns
-  for role-chaining accounts, so the provider no longer needs its client-side workarounds.
+  the `polaris_aws_cnp_permissions` data source. Role-chaining accounts surface the role under the `ROLE_CHAINING`
+  artifact key instead of `CROSSACCOUNT`; see the [v1.8.1 upgrade guide](upgrade_guide_v1.8.1.md) for the expected
+  one-time diff.
 
 ## v1.8.0
 * Add support for the `AzureNativeResourceGroup` object type in the `polaris_object` data source. Pair with the

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -4,11 +4,14 @@ page_title: "Changelog"
 
 # Changelog
 
-## v1.9.0
+## v1.8.1
 * Add support for the `SERVERS_AND_APPS` feature in the `polaris_gcp_project` resource and the `polaris_gcp_project`
   and `polaris_gcp_permissions` data sources. The feature uses the `CLOUD_CLUSTER_ES` permission group and, unlike
   other GCP features, does not use the `BASIC` permission group.
   [[docs](../resources/gcp_project.md)]
+* Fix ROLE_CHAINING handling in the `polaris_aws_cnp_account` and `polaris_aws_cnp_account_attachments` resources and
+  the `polaris_aws_cnp_permissions` data source. The Go SDK now filters the spurious CROSSACCOUNT artifact RSC returns
+  for role-chaining accounts, so the provider no longer needs its client-side workarounds.
 
 ## v1.8.0
 * Add support for the `AzureNativeResourceGroup` object type in the `polaris_object` data source. Pair with the

--- a/docs/guides/upgrade_guide_v1.8.1.md
+++ b/docs/guides/upgrade_guide_v1.8.1.md
@@ -1,0 +1,94 @@
+---
+page_title: "Upgrade Guide: v1.8.1"
+---
+
+# Upgrade Guide v1.8.1
+
+The v1.8.1 release changes how the AWS IAM roles workflow surfaces the artifact for a role-chaining account: the
+role-chaining role is now exposed under the `ROLE_CHAINING` artifact key instead of `CROSSACCOUNT`. The release also
+adds support for the GCP `SERVERS_AND_APPS` feature. See the [changelog](changelog.md) for the full list.
+
+## Before Upgrading
+
+Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
+provider.
+
+Starting with v1.7.0, each release is also published as the renamed `rubrikinc/rubrik` provider. The
+`rubrikinc/polaris` provider will continue to be released and supported for some time, so there is no need to switch
+right now. The `rubrikinc/polaris` provider will eventually be retired, however, and you will need to switch to the
+`rubrikinc/rubrik` provider before then. The migration paths will improve over time as more resources gain support for
+Terraform's `moved {}` block, making the switch progressively simpler. See the
+[latest upgrade guide for the rubrikinc/rubrik provider](https://registry.terraform.io/providers/rubrikinc/rubrik/latest/docs/guides)
+for the currently available migration paths.
+
+~> **Note:** If you are upgrading across multiple minor versions (e.g. v1.6.x to v1.8.1), review the upgrade guide for
+each intermediate version as well. Each guide documents breaking changes and migration steps specific to that release.
+
+## How to Upgrade
+
+Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.8.1 release. One
+way of doing this is by using the pessimistic constraint operator `~>`, which allows Terraform to upgrade to the latest
+release within the same minor version:
+```terraform
+terraform {
+  required_providers {
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "~> 1.8.1"
+    }
+  }
+}
+```
+Next, upgrade the provider to the new version by running:
+```shell
+% terraform init -upgrade
+```
+After the provider has been updated, validate the correctness of the Terraform configuration files by running:
+```shell
+% terraform plan
+```
+If you get an error or an unwanted diff, please see the _Significant Changes_ section below for additional instructions.
+Otherwise, proceed by running:
+```shell
+% terraform apply -refresh-only
+```
+This will read the remote state of the resources and migrate the local Terraform state to the v1.8.1 version.
+
+## Significant Changes
+
+### AWS Role Chaining Artifact Key
+
+Earlier releases surfaced the role-chaining role under the `CROSSACCOUNT` artifact key. It is now surfaced under the
+`ROLE_CHAINING` key, which matches the account's feature. This affects only role-chaining accounts, that is accounts
+whose sole feature is `ROLE_CHAINING`; other accounts are unchanged.
+
+After upgrading, a role-chaining account shows a one-time diff that settles after a single `apply`. The
+`polaris_aws_cnp_artifacts` data source returns `ROLE_CHAINING` in `role_keys` where it previously returned
+`CROSSACCOUNT`, and the `polaris_aws_cnp_permissions` data source reports the policy under the `ROLE_CHAINING` artifact
+with the policy name `RoleChainingPolicy` instead of `RoleChaining`. The permission policy document itself does not
+change — it is still an `sts:AssumeRole` policy with the same statements, and the role's trust relationship is also
+unchanged. Only the artifact key and the reported policy name differ.
+
+The diff matters because the [AWS IAM roles workflow](aws_cnp_account.md) guide keys its AWS resources on these values:
+`aws_iam_role` on `role_keys` and `aws_iam_policy` on the policy name. When those `for_each` keys change, Terraform
+destroys and recreates the role-chaining `aws_iam_role` and its `aws_iam_policy` under new ARNs, re-attaches them, and
+`polaris_aws_cnp_account_attachments` re-registers the role under the `ROLE_CHAINING` key with the recreated role's ARN.
+The new role carries the same trust relationship and permissions as the old one.
+
+No configuration change is required if your configuration iterates the artifacts and permissions data sources, as in
+that guide — the data sources now emit `ROLE_CHAINING` automatically and the role keys follow. Review the plan, then
+run `terraform apply` to let the diff settle.
+
+A configuration change is only required where the `CROSSACCOUNT` key is hardcoded, for example as the `role_key` of a
+`polaris_aws_cnp_permissions` data source. Update those references to `ROLE_CHAINING`:
+
+```terraform
+data "polaris_aws_cnp_permissions" "role_chaining" {
+  role_key = "ROLE_CHAINING"
+
+  feature {
+    name              = "ROLE_CHAINING"
+    permission_groups = ["BASIC"]
+  }
+}
+```

--- a/docs/resources/aws_cnp_account.md
+++ b/docs/resources/aws_cnp_account.md
@@ -283,8 +283,8 @@ Required:
 
 Read-Only:
 
-- `policy` (String) RSC artifact key for the AWS role.
-- `role_key` (String) AWS IAM trust policy.
+- `policy` (String) AWS IAM trust policy.
+- `role_key` (String) RSC artifact key for the AWS role. Possible values are `CROSSACCOUNT`, `EXOCOMPUTE_EKS_LAMBDA`, `EXOCOMPUTE_EKS_MASTERNODE`, `EXOCOMPUTE_EKS_WORKERNODE` and `ROLE_CHAINING`.
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.22.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.7.1-0.20260624130943-a9ef39862280
+	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.8.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.22.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.7.1-0.20260609132539-4fb5966f2df3
+	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.7.1-0.20260624130943-a9ef39862280
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.7.1-0.20260609132539-4fb5966f2df3 h1:kpOT9LZyLjnRLYN8j/NAmnJuA4n3FXcoN5gQ2q2fSu0=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.7.1-0.20260609132539-4fb5966f2df3/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.7.1-0.20260624130943-a9ef39862280 h1:eFbpEgj/3aESZe8cFA+qUbrLYuzx3gFWiIZcfE3YA14=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.7.1-0.20260624130943-a9ef39862280/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.7.1-0.20260624130943-a9ef39862280 h1:eFbpEgj/3aESZe8cFA+qUbrLYuzx3gFWiIZcfE3YA14=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.7.1-0.20260624130943-a9ef39862280/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.8.0 h1:1mPzeRZQ+/uKA4uuzhxUfpFCynrgTldjwq6WZuydpEM=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.8.0/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/internal/provider/data_source_aws_cnp_permissions.go
+++ b/internal/provider/data_source_aws_cnp_permissions.go
@@ -93,24 +93,6 @@ are used when specifying the feature set.
    is always required except for the ´SERVERS_AND_APPS´ feature.
 `
 
-// roleChainingSyntheticPolicy is the policy document injected when the RSC
-// backend does not return any policy data for the ROLE_CHAINING feature.
-const roleChainingSyntheticPolicy = `{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Sid": "RoleChainingPolicySid",
-            "Effect": "Allow",
-            "Action": [
-                "sts:AssumeRole"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ]
-}`
-
 // This data source uses a template for its documentation due to a bug in the TF
 // docs generator. Remember to update the template if the documentation for any
 // fields are changed.
@@ -213,18 +195,6 @@ func awsPermissionsRead(ctx context.Context, d *schema.ResourceData, m interface
 	customerPolicies, managedPolicies, err := aws.Wrap(client).Permissions(ctx, cloud, features, ec2RecoveryRolePath)
 	if err != nil {
 		return diag.FromErr(err)
-	}
-
-	// Workaround: the RSC backend does not return any policy data for
-	// the ROLE_CHAINING feature. Inject the expected sts:AssumeRole
-	// policy until the backend is fixed.
-	if len(features) == 1 && features[0].Equal(core.FeatureRoleChaining) && roleKey == "CROSSACCOUNT" && len(customerPolicies) == 0 {
-		customerPolicies = []aws.CustomerManagedPolicy{{
-			Artifact: roleKey,
-			Feature:  core.FeatureRoleChaining,
-			Name:     "RoleChaining",
-			Policy:   roleChainingSyntheticPolicy,
-		}}
 	}
 
 	slices.SortFunc(customerPolicies, func(i, j aws.CustomerManagedPolicy) int {

--- a/internal/provider/resource_aws_cnp_account.go
+++ b/internal/provider/resource_aws_cnp_account.go
@@ -629,7 +629,8 @@ func trustPolicyResource() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 				Description: "RSC artifact key for the AWS role. Possible values are `CROSSACCOUNT`, " +
-					"`EXOCOMPUTE_EKS_MASTERNODE`, `EXOCOMPUTE_EKS_WORKERNODE` and `EXOCOMPUTE_EKS_LAMBDA`.",
+					"`EXOCOMPUTE_EKS_LAMBDA`, `EXOCOMPUTE_EKS_MASTERNODE`, `EXOCOMPUTE_EKS_WORKERNODE` and " +
+					"`ROLE_CHAINING`.",
 			},
 			keyPolicy: {
 				Type:        schema.TypeString,

--- a/internal/provider/resource_aws_cnp_account_attachments.go
+++ b/internal/provider/resource_aws_cnp_account_attachments.go
@@ -140,8 +140,6 @@ func awsCreateCnpAccountAttachments(ctx context.Context, d *schema.ResourceData,
 		roles[block[keyKey].(string)] = block[keyARN].(string)
 	}
 
-	ensureRoleChainingArtifact(roles, features)
-
 	// Request artifacts be added to account.
 	var roleChainingAccountID uuid.UUID
 	if id, ok := d.GetOk(keyRoleChainingAccountID); ok {
@@ -214,12 +212,6 @@ func awsReadCnpAccountAttachments(ctx context.Context, d *schema.ResourceData, m
 		return diag.FromErr(err)
 	}
 
-	// Workaround: the ROLE_CHAINING artifact is registered as a
-	// duplicate of CROSSACCOUNT by the create function. Remove it from
-	// the read response so it doesn't appear in state and cause a
-	// perpetual diff.
-	delete(roles, "ROLE_CHAINING")
-
 	oldRoles := make(map[string]string)
 	for _, role := range d.Get(keyRole).(*schema.Set).List() {
 		block := role.(map[string]any)
@@ -263,8 +255,6 @@ func awsUpdateCnpAccountAttachments(ctx context.Context, d *schema.ResourceData,
 		block := roleAttr.(map[string]any)
 		roles[block[keyKey].(string)] = block[keyARN].(string)
 	}
-
-	ensureRoleChainingArtifact(roles, features)
 
 	// Update artifacts.
 	var roleChainingAccountID uuid.UUID
@@ -319,23 +309,6 @@ func accountFeatures(ctx context.Context, client *polaris.Client, accountID uuid
 		features = append(features, f.Feature)
 	}
 	return features, nil
-}
-
-// ensureRoleChainingArtifact duplicates the CROSSACCOUNT role ARN as
-// ROLE_CHAINING when the ROLE_CHAINING feature is present. This is a
-// workaround for the RSC backend not returning the ROLE_CHAINING_ROLE_ARN
-// artifact.
-func ensureRoleChainingArtifact(roles map[string]string, features []core.Feature) {
-	crossAccountARN, ok := roles["CROSSACCOUNT"]
-	if !ok {
-		return
-	}
-	if _, ok := roles["ROLE_CHAINING"]; ok {
-		return
-	}
-	if _, ok := core.LookupFeature(features, core.FeatureRoleChaining); ok {
-		roles["ROLE_CHAINING"] = crossAccountARN
-	}
 }
 
 func awsCustomizeDiffCnpAccountAttachments(ctx context.Context, diff *schema.ResourceDiff, m any) error {

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -10,8 +10,9 @@ page_title: "Changelog"
   other GCP features, does not use the `BASIC` permission group.
   [[docs](../resources/gcp_project.md)]
 * Fix ROLE_CHAINING handling in the `polaris_aws_cnp_account` and `polaris_aws_cnp_account_attachments` resources and
-  the `polaris_aws_cnp_permissions` data source. The Go SDK now filters the spurious CROSSACCOUNT artifact RSC returns
-  for role-chaining accounts, so the provider no longer needs its client-side workarounds.
+  the `polaris_aws_cnp_permissions` data source. Role-chaining accounts surface the role under the `ROLE_CHAINING`
+  artifact key instead of `CROSSACCOUNT`; see the [v1.8.1 upgrade guide](upgrade_guide_v1.8.1.md) for the expected
+  one-time diff.
 
 ## v1.8.0
 * Add support for the `AzureNativeResourceGroup` object type in the `polaris_object` data source. Pair with the

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -4,11 +4,14 @@ page_title: "Changelog"
 
 # Changelog
 
-## v1.9.0
+## v1.8.1
 * Add support for the `SERVERS_AND_APPS` feature in the `polaris_gcp_project` resource and the `polaris_gcp_project`
   and `polaris_gcp_permissions` data sources. The feature uses the `CLOUD_CLUSTER_ES` permission group and, unlike
   other GCP features, does not use the `BASIC` permission group.
   [[docs](../resources/gcp_project.md)]
+* Fix ROLE_CHAINING handling in the `polaris_aws_cnp_account` and `polaris_aws_cnp_account_attachments` resources and
+  the `polaris_aws_cnp_permissions` data source. The Go SDK now filters the spurious CROSSACCOUNT artifact RSC returns
+  for role-chaining accounts, so the provider no longer needs its client-side workarounds.
 
 ## v1.8.0
 * Add support for the `AzureNativeResourceGroup` object type in the `polaris_object` data source. Pair with the

--- a/templates/guides/upgrade_guide_v1.8.1.md.tmpl
+++ b/templates/guides/upgrade_guide_v1.8.1.md.tmpl
@@ -1,0 +1,94 @@
+---
+page_title: "Upgrade Guide: v1.8.1"
+---
+
+# Upgrade Guide v1.8.1
+
+The v1.8.1 release changes how the AWS IAM roles workflow surfaces the artifact for a role-chaining account: the
+role-chaining role is now exposed under the `ROLE_CHAINING` artifact key instead of `CROSSACCOUNT`. The release also
+adds support for the GCP `SERVERS_AND_APPS` feature. See the [changelog](changelog.md) for the full list.
+
+## Before Upgrading
+
+Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
+provider.
+
+Starting with v1.7.0, each release is also published as the renamed `rubrikinc/rubrik` provider. The
+`rubrikinc/polaris` provider will continue to be released and supported for some time, so there is no need to switch
+right now. The `rubrikinc/polaris` provider will eventually be retired, however, and you will need to switch to the
+`rubrikinc/rubrik` provider before then. The migration paths will improve over time as more resources gain support for
+Terraform's `moved {}` block, making the switch progressively simpler. See the
+[latest upgrade guide for the rubrikinc/rubrik provider](https://registry.terraform.io/providers/rubrikinc/rubrik/latest/docs/guides)
+for the currently available migration paths.
+
+~> **Note:** If you are upgrading across multiple minor versions (e.g. v1.6.x to v1.8.1), review the upgrade guide for
+each intermediate version as well. Each guide documents breaking changes and migration steps specific to that release.
+
+## How to Upgrade
+
+Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.8.1 release. One
+way of doing this is by using the pessimistic constraint operator `~>`, which allows Terraform to upgrade to the latest
+release within the same minor version:
+```terraform
+terraform {
+  required_providers {
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "~> 1.8.1"
+    }
+  }
+}
+```
+Next, upgrade the provider to the new version by running:
+```shell
+% terraform init -upgrade
+```
+After the provider has been updated, validate the correctness of the Terraform configuration files by running:
+```shell
+% terraform plan
+```
+If you get an error or an unwanted diff, please see the _Significant Changes_ section below for additional instructions.
+Otherwise, proceed by running:
+```shell
+% terraform apply -refresh-only
+```
+This will read the remote state of the resources and migrate the local Terraform state to the v1.8.1 version.
+
+## Significant Changes
+
+### AWS Role Chaining Artifact Key
+
+Earlier releases surfaced the role-chaining role under the `CROSSACCOUNT` artifact key. It is now surfaced under the
+`ROLE_CHAINING` key, which matches the account's feature. This affects only role-chaining accounts, that is accounts
+whose sole feature is `ROLE_CHAINING`; other accounts are unchanged.
+
+After upgrading, a role-chaining account shows a one-time diff that settles after a single `apply`. The
+`polaris_aws_cnp_artifacts` data source returns `ROLE_CHAINING` in `role_keys` where it previously returned
+`CROSSACCOUNT`, and the `polaris_aws_cnp_permissions` data source reports the policy under the `ROLE_CHAINING` artifact
+with the policy name `RoleChainingPolicy` instead of `RoleChaining`. The permission policy document itself does not
+change — it is still an `sts:AssumeRole` policy with the same statements, and the role's trust relationship is also
+unchanged. Only the artifact key and the reported policy name differ.
+
+The diff matters because the [AWS IAM roles workflow](aws_cnp_account.md) guide keys its AWS resources on these values:
+`aws_iam_role` on `role_keys` and `aws_iam_policy` on the policy name. When those `for_each` keys change, Terraform
+destroys and recreates the role-chaining `aws_iam_role` and its `aws_iam_policy` under new ARNs, re-attaches them, and
+`polaris_aws_cnp_account_attachments` re-registers the role under the `ROLE_CHAINING` key with the recreated role's ARN.
+The new role carries the same trust relationship and permissions as the old one.
+
+No configuration change is required if your configuration iterates the artifacts and permissions data sources, as in
+that guide — the data sources now emit `ROLE_CHAINING` automatically and the role keys follow. Review the plan, then
+run `terraform apply` to let the diff settle.
+
+A configuration change is only required where the `CROSSACCOUNT` key is hardcoded, for example as the `role_key` of a
+`polaris_aws_cnp_permissions` data source. Update those references to `ROLE_CHAINING`:
+
+```terraform
+data "polaris_aws_cnp_permissions" "role_chaining" {
+  role_key = "ROLE_CHAINING"
+
+  feature {
+    name              = "ROLE_CHAINING"
+    permission_groups = ["BASIC"]
+  }
+}
+```

--- a/templates/resources/aws_cnp_account.md.tmpl
+++ b/templates/resources/aws_cnp_account.md.tmpl
@@ -49,8 +49,8 @@ Required:
 
 Read-Only:
 
-- `policy` (String) RSC artifact key for the AWS role.
-- `role_key` (String) AWS IAM trust policy.
+- `policy` (String) AWS IAM trust policy.
+- `role_key` (String) RSC artifact key for the AWS role. Possible values are `CROSSACCOUNT`, `EXOCOMPUTE_EKS_LAMBDA`, `EXOCOMPUTE_EKS_MASTERNODE`, `EXOCOMPUTE_EKS_WORKERNODE` and `ROLE_CHAINING`.
 
 ## Import
 


### PR DESCRIPTION
# Description

Removes the client-side `ROLE_CHAINING` workarounds from the AWS CNP resources and data sources now that the Go SDK filters the spurious duplicate `CROSSACCOUNT` role artifact that RSC returns for role-chaining-only accounts, and RSC returns a real `ROLE_CHAINING` permission policy. The SDK dependency is bumped to pick up the artifact filtering. Specifically, this drops the synthetic `sts:AssumeRole` policy injected by the `polaris_aws_cnp_permissions` data source, the `ensureRoleChainingArtifact` helper that duplicated `CROSSACCOUNT` as `ROLE_CHAINING` in `polaris_aws_cnp_account_attachments`, and the read-path delete that hid the synthesized artifact. The `role_key` description on `polaris_aws_cnp_account` now lists `ROLE_CHAINING`.

A v1.8.1 upgrade guide is added documenting the one-time diff role-chaining accounts see when the role-chaining role moves from the `CROSSACCOUNT` artifact key to `ROLE_CHAINING`, and the changelog links to it.

## Related Issue

[#389](https://github.com/rubrikinc/rubrik-polaris-sdk-for-go/pull/389)

## Motivation and Context

Earlier releases compensated for backend gaps by synthesizing the `ROLE_CHAINING` artifact from `CROSSACCOUNT`, stripping it on read to avoid a perpetual diff, and injecting a synthetic `sts:AssumeRole` policy. RSC now returns proper `ROLE_CHAINING` artifacts and the SDK drops the duplicate `CROSSACCOUNT` artifact, so these workarounds are obsolete and the role-chaining role is correctly surfaced under the `ROLE_CHAINING` artifact key that matches the account's feature.

## How Has This Been Tested?

Manually onboarded a role-chaining account and a role-chained account and verified onboarding completes and the configuration settles. In addition, `go build ./...`, `go vet ./...`, `gofmt` and `go test ./internal/provider/...` all pass, and `go generate ./...` produces no uncommitted drift.

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
