### PR TITLE
Reject VIEW_CLUSTER without VIEW_CLUSTER_REFERENCE

### DIFF
--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -4,6 +4,12 @@ page_title: "Changelog"
 
 # Changelog
 
+## v1.9.0
+* **Breaking Change:** The `polaris_custom_role` resource now requires the `VIEW_CLUSTER_REFERENCE` permission
+  operation to be granted alongside `VIEW_CLUSTER`. RSC automatically adds `VIEW_CLUSTER_REFERENCE` whenever
+  `VIEW_CLUSTER` is granted, so granting `VIEW_CLUSTER` alone resulted in perpetual drift. `VIEW_CLUSTER_REFERENCE`
+  may still be granted on its own. See the [v1.9.0 upgrade guide](upgrade_guide_v1.9.0.md).
+
 ## v1.8.1
 * Add support for the `SERVERS_AND_APPS` feature in the `polaris_gcp_project` resource and the `polaris_gcp_project`
   and `polaris_gcp_permissions` data sources. The feature uses the `CLOUD_CLUSTER_ES` permission group and, unlike

--- a/docs/guides/upgrade_guide_v1.9.0.md
+++ b/docs/guides/upgrade_guide_v1.9.0.md
@@ -1,0 +1,95 @@
+---
+page_title: "Upgrade Guide: v1.9.0"
+---
+
+# Upgrade Guide v1.9.0
+
+The v1.9.0 release adds a plan-time validation to the `polaris_custom_role` resource: a role that grants the
+`VIEW_CLUSTER` operation must now also grant `VIEW_CLUSTER_REFERENCE`. See the [changelog](changelog.md) for the full
+list of changes.
+
+## Before Upgrading
+
+Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
+provider.
+
+Starting with v1.7.0, each release is also published as the renamed `rubrikinc/rubrik` provider. The
+`rubrikinc/polaris` provider will continue to be released and supported for some time, so there is no need to switch
+right now. The `rubrikinc/polaris` provider will eventually be retired, however, and you will need to switch to the
+`rubrikinc/rubrik` provider before then. The migration paths will improve over time as more resources gain support for
+Terraform's `moved {}` block, making the switch progressively simpler. See the
+[latest upgrade guide for the rubrikinc/rubrik provider](https://registry.terraform.io/providers/rubrikinc/rubrik/latest/docs/guides)
+for the currently available migration paths.
+
+~> **Note:** If you are upgrading across multiple minor versions (e.g. v1.7.x to v1.9.0), review the upgrade guide for
+each intermediate version as well. Each guide documents breaking changes and migration steps specific to that release.
+
+## How to Upgrade
+
+Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.9.0 release. One
+way of doing this is by using the pessimistic constraint operator `~>`, which allows Terraform to upgrade to the latest
+release within the same minor version:
+```terraform
+terraform {
+  required_providers {
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "~> 1.9.0"
+    }
+  }
+}
+```
+Next, upgrade the provider to the new version by running:
+```shell
+% terraform init -upgrade
+```
+After the provider has been updated, validate the correctness of the Terraform configuration files by running:
+```shell
+% terraform plan
+```
+If you get an error or an unwanted diff, please see the _Significant Changes_ section below for additional instructions.
+Otherwise, proceed by running:
+```shell
+% terraform apply -refresh-only
+```
+This will read the remote state of the resources and migrate the local Terraform state to the v1.9.0 version.
+
+## Significant Changes
+
+### Custom Role VIEW_CLUSTER Now Requires VIEW_CLUSTER_REFERENCE
+
+The `polaris_custom_role` resource now validates, at plan time, that any role granting the `VIEW_CLUSTER` operation
+also grants `VIEW_CLUSTER_REFERENCE`. RSC automatically grants `VIEW_CLUSTER_REFERENCE` whenever `VIEW_CLUSTER` is
+granted, so a configuration that listed `VIEW_CLUSTER` alone never converged: every `terraform plan` reported the
+auto-granted `VIEW_CLUSTER_REFERENCE` as a diff. `VIEW_CLUSTER_REFERENCE` may still be granted on its own — it is a
+narrower permission that RSC does not expand.
+
+If you have a role that grants `VIEW_CLUSTER`, add a matching `VIEW_CLUSTER_REFERENCE` permission block. Otherwise
+`terraform plan` fails with:
+```
+Error: VIEW_CLUSTER requires VIEW_CLUSTER_REFERENCE
+```
+For example, a role that previously granted only `VIEW_CLUSTER`:
+```terraform
+resource "polaris_custom_role" "cluster_viewer" {
+  name = "Cluster Viewer"
+
+  permission {
+    operation = "VIEW_CLUSTER"
+    hierarchy {
+      snappable_type = "AllSubHierarchyType"
+      object_ids     = ["CLUSTER_ROOT"]
+    }
+  }
+
+  permission {
+    operation = "VIEW_CLUSTER_REFERENCE"
+    hierarchy {
+      snappable_type = "AllSubHierarchyType"
+      object_ids     = ["CLUSTER_ROOT"]
+    }
+  }
+}
+```
+After adding the `VIEW_CLUSTER_REFERENCE` permission, the previously perpetual diff disappears and the Terraform state
+matches the configuration.

--- a/docs/resources/custom_role.md
+++ b/docs/resources/custom_role.md
@@ -5,12 +5,23 @@ subcategory: ""
 description: |-
   The polaris_custom_role resource is used to create and manage custom roles in
   RSC.
+  -> Note: Granting the VIEW_CLUSTER operation requires also granting
+  VIEW_CLUSTER_REFERENCE. RSC automatically grants VIEW_CLUSTER_REFERENCE
+  whenever VIEW_CLUSTER is granted, so specifying VIEW_CLUSTER alone results
+  in perpetual configuration drift. VIEW_CLUSTER_REFERENCE may be granted on
+  its own.
 ---
 
 # polaris_custom_role (Resource)
 
 The `polaris_custom_role` resource is used to create and manage custom roles in
 RSC.
+
+-> **Note:** Granting the `VIEW_CLUSTER` operation requires also granting
+   `VIEW_CLUSTER_REFERENCE`. RSC automatically grants `VIEW_CLUSTER_REFERENCE`
+   whenever `VIEW_CLUSTER` is granted, so specifying `VIEW_CLUSTER` alone results
+   in perpetual configuration drift. `VIEW_CLUSTER_REFERENCE` may be granted on
+   its own.
 
 ## Example Usage
 

--- a/internal/provider/framework_data_source_role_test.go
+++ b/internal/provider/framework_data_source_role_test.go
@@ -55,6 +55,13 @@ func TestAccRoleDataSource(t *testing.T) {
 							object_ids     = ["CLUSTER_ROOT"]
 						}
 					}
+					permission {
+						operation = "VIEW_CLUSTER_REFERENCE"
+						hierarchy {
+							snappable_type = "AllSubHierarchyType"
+							object_ids     = ["CLUSTER_ROOT"]
+						}
+					}
 				}
 
 				data "polaris_role" "by_id" {
@@ -141,6 +148,13 @@ func TestAccRoleDataSource_FrameworkMigration(t *testing.T) {
 
 					permission {
 						operation = "VIEW_CLUSTER"
+						hierarchy {
+							snappable_type = "AllSubHierarchyType"
+							object_ids     = ["CLUSTER_ROOT"]
+						}
+					}
+					permission {
+						operation = "VIEW_CLUSTER_REFERENCE"
 						hierarchy {
 							snappable_type = "AllSubHierarchyType"
 							object_ids     = ["CLUSTER_ROOT"]

--- a/internal/provider/framework_fixtures_test.go
+++ b/internal/provider/framework_fixtures_test.go
@@ -95,8 +95,8 @@ func checkTestSSOGroup(t *testing.T, name string) string {
 }
 
 // createTestRole creates a custom role via the SDK and registers a cleanup
-// function to delete it. The role will have the VIEW_CLUSTER permission on the
-// CLUSTER_ROOT. Returns the role ID.
+// function to delete it. The role will have the VIEW_CLUSTER and
+// VIEW_CLUSTER_REFERENCE permissions on the CLUSTER_ROOT. Returns the role ID.
 func createTestRole(t *testing.T, name string) uuid.UUID {
 	t.Helper()
 	skipIfNotAcceptance(t)
@@ -109,6 +109,12 @@ func createTestRole(t *testing.T, name string) uuid.UUID {
 	desc := "Test Role: Delete Me!"
 	roleID, err := access.Wrap(polarisClient).CreateRole(t.Context(), name, desc, []gqlaccess.Permission{{
 		Operation: "VIEW_CLUSTER",
+		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
+			SnappableType: "AllSubHierarchyType",
+			ObjectIDs:     []string{"CLUSTER_ROOT"},
+		}},
+	}, {
+		Operation: "VIEW_CLUSTER_REFERENCE",
 		ObjectsForHierarchyTypes: []gqlaccess.ObjectsForHierarchyType{{
 			SnappableType: "AllSubHierarchyType",
 			ObjectIDs:     []string{"CLUSTER_ROOT"},
@@ -129,7 +135,8 @@ func createTestRole(t *testing.T, name string) uuid.UUID {
 
 // createTestRoleWithUniqueName creates a custom role with a unqiue name via
 // the SDK and registers a cleanup function to delete it. The role will have
-// the VIEW_CLUSTER permission on the CLUSTER_ROOT. Returns the role ID.
+// the VIEW_CLUSTER and VIEW_CLUSTER_REFERENCE permissions on the CLUSTER_ROOT.
+// Returns the role ID.
 func createTestRoleWithUniqueName(t *testing.T) uuid.UUID {
 	t.Helper()
 	skipIfNotAcceptance(t)

--- a/internal/provider/framework_resource_custom_role.go
+++ b/internal/provider/framework_resource_custom_role.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/identityschema"
@@ -37,17 +38,25 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/access"
 	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql"
+	gqlaccess "github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/access"
 )
 
 const resourceCustomRoleDescription = `
 The ´polaris_custom_role´ resource is used to create and manage custom roles in
 RSC.
+
+-> **Note:** Granting the ´VIEW_CLUSTER´ operation requires also granting
+   ´VIEW_CLUSTER_REFERENCE´. RSC automatically grants ´VIEW_CLUSTER_REFERENCE´
+   whenever ´VIEW_CLUSTER´ is granted, so specifying ´VIEW_CLUSTER´ alone results
+   in perpetual configuration drift. ´VIEW_CLUSTER_REFERENCE´ may be granted on
+   its own.
 `
 
 var (
-	_ resource.Resource                = &customRoleResource{}
-	_ resource.ResourceWithIdentity    = &customRoleResource{}
-	_ resource.ResourceWithImportState = &customRoleResource{}
+	_ resource.Resource                   = &customRoleResource{}
+	_ resource.ResourceWithIdentity       = &customRoleResource{}
+	_ resource.ResourceWithImportState    = &customRoleResource{}
+	_ resource.ResourceWithValidateConfig = &customRoleResource{}
 )
 
 type customRoleResource struct {
@@ -150,6 +159,60 @@ func (r *customRoleResource) Schema(ctx context.Context, _ resource.SchemaReques
 			},
 		},
 	}
+}
+
+func (r *customRoleResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, res *resource.ValidateConfigResponse) {
+	tflog.Trace(ctx, "customRoleResource.ValidateConfig")
+
+	var config customRoleModel
+	res.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if res.Diagnostics.HasError() {
+		return
+	}
+
+	res.Diagnostics.Append(validateCustomRoleConfig(ctx, config)...)
+}
+
+// validateCustomRoleConfig holds the plan-time, client-free validation rules
+// for the resource so they can be unit-tested in isolation.
+func validateCustomRoleConfig(ctx context.Context, config customRoleModel) diag.Diagnostics {
+	if config.Permission.IsNull() || config.Permission.IsUnknown() {
+		return nil
+	}
+
+	var perms []permissionModel
+	var diags diag.Diagnostics
+	diags.Append(config.Permission.ElementsAs(ctx, &perms, false)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	var hasViewCluster, hasViewClusterReference bool
+	for _, p := range perms {
+		switch {
+		case p.Operation.IsUnknown():
+			return diags
+		case p.Operation.ValueString() == string(gqlaccess.OperationViewCluster):
+			hasViewCluster = true
+		case p.Operation.ValueString() == string(gqlaccess.OperationViewClusterReference):
+			hasViewClusterReference = true
+		}
+	}
+
+	// The dependency is one-directional: RSC grants VIEW_CLUSTER_REFERENCE
+	// automatically when VIEW_CLUSTER is granted, so VIEW_CLUSTER without
+	// VIEW_CLUSTER_REFERENCE drifts. VIEW_CLUSTER_REFERENCE on its own is a valid,
+	// narrower permission and is allowed.
+	if hasViewCluster && !hasViewClusterReference {
+		diags.AddAttributeError(path.Root(keyPermission),
+			"VIEW_CLUSTER requires VIEW_CLUSTER_REFERENCE",
+			"RSC automatically grants the VIEW_CLUSTER_REFERENCE permission whenever VIEW_CLUSTER is "+
+				"granted. Add a VIEW_CLUSTER_REFERENCE permission to keep Terraform state consistent "+
+				"and avoid perpetual drift.",
+		)
+	}
+
+	return diags
 }
 
 func (r *customRoleResource) IdentitySchema(ctx context.Context, _ resource.IdentitySchemaRequest, res *resource.IdentitySchemaResponse) {

--- a/internal/provider/framework_resource_custom_role_test.go
+++ b/internal/provider/framework_resource_custom_role_test.go
@@ -21,12 +21,17 @@
 package provider
 
 import (
+	"context"
+	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
 	"github.com/hashicorp/terraform-plugin-testing/statecheck"
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/access"
+	"github.com/rubrikinc/rubrik-polaris-sdk-for-go/pkg/polaris/graphql/hierarchy"
 )
 
 func TestAccCustomRoleResource(t *testing.T) {
@@ -93,6 +98,13 @@ func TestAccCustomRoleResource(t *testing.T) {
 							object_ids     = ["CLUSTER_ROOT"]
 						}
 					}
+					permission {
+						operation = "VIEW_CLUSTER_REFERENCE"
+						hierarchy {
+							snappable_type = "AllSubHierarchyType"
+							object_ids     = ["CLUSTER_ROOT"]
+						}
+					}
 				}
 			`,
 			ConfigStateChecks: []statecheck.StateCheck{
@@ -114,6 +126,15 @@ func TestAccCustomRoleResource(t *testing.T) {
 						}),
 						knownvalue.ObjectExact(map[string]knownvalue.Check{
 							keyOperation: knownvalue.StringExact("VIEW_CLUSTER"),
+							keyHierarchy: knownvalue.SetExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+								keySnappableType: knownvalue.StringExact("AllSubHierarchyType"),
+								keyObjectIDs: knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("CLUSTER_ROOT"),
+								}),
+							})}),
+						}),
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							keyOperation: knownvalue.StringExact("VIEW_CLUSTER_REFERENCE"),
 							keyHierarchy: knownvalue.SetExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
 								keySnappableType: knownvalue.StringExact("AllSubHierarchyType"),
 								keyObjectIDs: knownvalue.SetExact([]knownvalue.Check{
@@ -224,6 +245,13 @@ func TestAccCustomRoleResource_FrameworkMigration(t *testing.T) {
 					object_ids     = ["CLUSTER_ROOT"]
 				}
 			}
+			permission {
+				operation = "VIEW_CLUSTER_REFERENCE"
+				hierarchy {
+					snappable_type = "AllSubHierarchyType"
+					object_ids     = ["CLUSTER_ROOT"]
+				}
+			}
 		}
 	`
 
@@ -251,4 +279,123 @@ func TestAccCustomRoleResource_FrameworkMigration(t *testing.T) {
 			PlanOnly:                 true,
 		}},
 	})
+}
+
+// TestAccCustomRoleResource_ViewClusterOnly verifies that the config validator
+// rejects a role granting VIEW_CLUSTER without VIEW_CLUSTER_REFERENCE. The error
+// is raised at plan time, so no role is created and the step never reaches apply.
+func TestAccCustomRoleResource_ViewClusterOnly(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactories,
+		Steps: []resource.TestStep{{
+			Config: `
+				resource "polaris_custom_role" "role" {
+					name        = "Test Cluster Viewer"
+					description = "Test Role: Delete Me!"
+
+					permission {
+						operation = "VIEW_CLUSTER"
+						hierarchy {
+							snappable_type = "AllSubHierarchyType"
+							object_ids     = ["CLUSTER_ROOT"]
+						}
+					}
+				}
+			`,
+			ExpectError: regexp.MustCompile("(?s)VIEW_CLUSTER requires VIEW_CLUSTER_REFERENCE"),
+		}},
+	})
+}
+
+// TestAccCustomRoleResource_ViewClusterReferenceOnly verifies that a role with
+// only the VIEW_CLUSTER_REFERENCE operation, i.e. without VIEW_CLUSTER, is
+// accepted by the validator and does not drift. VIEW_CLUSTER_REFERENCE is a
+// narrower permission that RSC does not expand, so the applied permission set
+// must remain exactly as configured.
+func TestAccCustomRoleResource_ViewClusterReferenceOnly(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactories,
+		CheckDestroy:             customRoleCheckDestroy(t.Context()),
+		Steps: []resource.TestStep{{
+			Config: `
+				resource "polaris_custom_role" "role" {
+					name        = "Test Cluster Reference Viewer"
+					description = "Test Role: Delete Me!"
+
+					permission {
+						operation = "VIEW_CLUSTER_REFERENCE"
+						hierarchy {
+							snappable_type = "AllSubHierarchyType"
+							object_ids     = ["CLUSTER_ROOT"]
+						}
+					}
+				}
+			`,
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectKnownValue("polaris_custom_role.role", tfjsonpath.New(keyID),
+					NonNullUUID()),
+				// The permission set must remain exactly VIEW_CLUSTER_REFERENCE. If
+				// RSC expanded it (for example by adding VIEW_CLUSTER) this check
+				// would fail.
+				statecheck.ExpectKnownValue("polaris_custom_role.role", tfjsonpath.New(keyPermission),
+					knownvalue.SetExact([]knownvalue.Check{
+						knownvalue.ObjectExact(map[string]knownvalue.Check{
+							keyOperation: knownvalue.StringExact("VIEW_CLUSTER_REFERENCE"),
+							keyHierarchy: knownvalue.SetExact([]knownvalue.Check{knownvalue.ObjectExact(map[string]knownvalue.Check{
+								keySnappableType: knownvalue.StringExact("AllSubHierarchyType"),
+								keyObjectIDs: knownvalue.SetExact([]knownvalue.Check{
+									knownvalue.StringExact("CLUSTER_ROOT"),
+								}),
+							})}),
+						}),
+					})),
+			},
+		}},
+	})
+}
+
+func TestValidateCustomRoleConfig(t *testing.T) {
+	ctx := context.Background()
+
+	// permSet builds a permission set with one hierarchy per operation so the
+	// config mirrors a realistic custom role.
+	permSet := func(operations ...access.Operation) types.Set {
+		perms := make([]access.Permission, 0, len(operations))
+		for _, op := range operations {
+			perms = append(perms, access.Permission{
+				Operation: string(op),
+				ObjectsForHierarchyTypes: []access.ObjectsForHierarchyType{{
+					SnappableType: "AllSubHierarchyType",
+					ObjectIDs:     []string{hierarchy.ClusterRoot},
+				}},
+			})
+		}
+		set, diags := fromPermissions(ctx, perms)
+		if diags.HasError() {
+			t.Fatalf("fromPermissions: %v", diags)
+		}
+		return set
+	}
+
+	tests := []struct {
+		name       string
+		permission types.Set
+		wantErr    bool
+	}{
+		{"both present", permSet(access.OperationViewCluster, access.OperationViewClusterReference), false},
+		{"both present with another operation", permSet("EXPORT_DATA_CLASS_GLOBAL", access.OperationViewCluster, access.OperationViewClusterReference), false},
+		{"neither present", permSet("EXPORT_DATA_CLASS_GLOBAL"), false},
+		{"only view_cluster", permSet(access.OperationViewCluster), true},
+		{"only view_cluster_reference is allowed", permSet(access.OperationViewClusterReference), false},
+		{"null permission set", types.SetNull(types.ObjectType{AttrTypes: permissionModelAttrTypes()}), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			diags := validateCustomRoleConfig(ctx, customRoleModel{Permission: tt.permission})
+			if got := diags.HasError(); got != tt.wantErr {
+				t.Errorf("validateCustomRoleConfig() error = %v, wantErr %v: %v", got, tt.wantErr, diags)
+			}
+		})
+	}
 }

--- a/internal/provider/framework_resource_role_assignment_test.go
+++ b/internal/provider/framework_resource_role_assignment_test.go
@@ -136,6 +136,13 @@ func TestAccRoleAssignmentResource(t *testing.T) {
 							object_ids     = ["CLUSTER_ROOT"]
 						}
 					}
+					permission {
+						operation = "VIEW_CLUSTER_REFERENCE"
+						hierarchy {
+							snappable_type = "AllSubHierarchyType"
+							object_ids     = ["CLUSTER_ROOT"]
+						}
+					}
 				}
 
 				resource "polaris_role_assignment" "auditor" {

--- a/internal/provider/framework_resource_user_test.go
+++ b/internal/provider/framework_resource_user_test.go
@@ -133,6 +133,13 @@ func TestAccUserResource(t *testing.T) {
 							object_ids     = ["CLUSTER_ROOT"]
 						}
 					}
+					permission {
+						operation = "VIEW_CLUSTER_REFERENCE"
+						hierarchy {
+							snappable_type = "AllSubHierarchyType"
+							object_ids     = ["CLUSTER_ROOT"]
+						}
+					}
 				}
 
 				resource "polaris_user" "user" {

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -4,6 +4,12 @@ page_title: "Changelog"
 
 # Changelog
 
+## v1.9.0
+* **Breaking Change:** The `polaris_custom_role` resource now requires the `VIEW_CLUSTER_REFERENCE` permission
+  operation to be granted alongside `VIEW_CLUSTER`. RSC automatically adds `VIEW_CLUSTER_REFERENCE` whenever
+  `VIEW_CLUSTER` is granted, so granting `VIEW_CLUSTER` alone resulted in perpetual drift. `VIEW_CLUSTER_REFERENCE`
+  may still be granted on its own. See the [v1.9.0 upgrade guide](upgrade_guide_v1.9.0.md).
+
 ## v1.8.1
 * Add support for the `SERVERS_AND_APPS` feature in the `polaris_gcp_project` resource and the `polaris_gcp_project`
   and `polaris_gcp_permissions` data sources. The feature uses the `CLOUD_CLUSTER_ES` permission group and, unlike

--- a/templates/guides/upgrade_guide_v1.9.0.md.tmpl
+++ b/templates/guides/upgrade_guide_v1.9.0.md.tmpl
@@ -1,0 +1,95 @@
+---
+page_title: "Upgrade Guide: v1.9.0"
+---
+
+# Upgrade Guide v1.9.0
+
+The v1.9.0 release adds a plan-time validation to the `polaris_custom_role` resource: a role that grants the
+`VIEW_CLUSTER` operation must now also grant `VIEW_CLUSTER_REFERENCE`. See the [changelog](changelog.md) for the full
+list of changes.
+
+## Before Upgrading
+
+Review the [changelog](changelog.md) to understand what has changed and what might cause an issue when upgrading the
+provider.
+
+Starting with v1.7.0, each release is also published as the renamed `rubrikinc/rubrik` provider. The
+`rubrikinc/polaris` provider will continue to be released and supported for some time, so there is no need to switch
+right now. The `rubrikinc/polaris` provider will eventually be retired, however, and you will need to switch to the
+`rubrikinc/rubrik` provider before then. The migration paths will improve over time as more resources gain support for
+Terraform's `moved {}` block, making the switch progressively simpler. See the
+[latest upgrade guide for the rubrikinc/rubrik provider](https://registry.terraform.io/providers/rubrikinc/rubrik/latest/docs/guides)
+for the currently available migration paths.
+
+~> **Note:** If you are upgrading across multiple minor versions (e.g. v1.7.x to v1.9.0), review the upgrade guide for
+each intermediate version as well. Each guide documents breaking changes and migration steps specific to that release.
+
+## How to Upgrade
+
+Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.9.0 release. One
+way of doing this is by using the pessimistic constraint operator `~>`, which allows Terraform to upgrade to the latest
+release within the same minor version:
+```terraform
+terraform {
+  required_providers {
+    polaris = {
+      source  = "rubrikinc/polaris"
+      version = "~> 1.9.0"
+    }
+  }
+}
+```
+Next, upgrade the provider to the new version by running:
+```shell
+% terraform init -upgrade
+```
+After the provider has been updated, validate the correctness of the Terraform configuration files by running:
+```shell
+% terraform plan
+```
+If you get an error or an unwanted diff, please see the _Significant Changes_ section below for additional instructions.
+Otherwise, proceed by running:
+```shell
+% terraform apply -refresh-only
+```
+This will read the remote state of the resources and migrate the local Terraform state to the v1.9.0 version.
+
+## Significant Changes
+
+### Custom Role VIEW_CLUSTER Now Requires VIEW_CLUSTER_REFERENCE
+
+The `polaris_custom_role` resource now validates, at plan time, that any role granting the `VIEW_CLUSTER` operation
+also grants `VIEW_CLUSTER_REFERENCE`. RSC automatically grants `VIEW_CLUSTER_REFERENCE` whenever `VIEW_CLUSTER` is
+granted, so a configuration that listed `VIEW_CLUSTER` alone never converged: every `terraform plan` reported the
+auto-granted `VIEW_CLUSTER_REFERENCE` as a diff. `VIEW_CLUSTER_REFERENCE` may still be granted on its own — it is a
+narrower permission that RSC does not expand.
+
+If you have a role that grants `VIEW_CLUSTER`, add a matching `VIEW_CLUSTER_REFERENCE` permission block. Otherwise
+`terraform plan` fails with:
+```
+Error: VIEW_CLUSTER requires VIEW_CLUSTER_REFERENCE
+```
+For example, a role that previously granted only `VIEW_CLUSTER`:
+```terraform
+resource "polaris_custom_role" "cluster_viewer" {
+  name = "Cluster Viewer"
+
+  permission {
+    operation = "VIEW_CLUSTER"
+    hierarchy {
+      snappable_type = "AllSubHierarchyType"
+      object_ids     = ["CLUSTER_ROOT"]
+    }
+  }
+
+  permission {
+    operation = "VIEW_CLUSTER_REFERENCE"
+    hierarchy {
+      snappable_type = "AllSubHierarchyType"
+      object_ids     = ["CLUSTER_ROOT"]
+    }
+  }
+}
+```
+After adding the `VIEW_CLUSTER_REFERENCE` permission, the previously perpetual diff disappears and the Terraform state
+matches the configuration.


### PR DESCRIPTION
# Description

Backport of [terraform-provider-rubrik #40](https://github.com/rubrikinc/terraform-provider-rubrik/pull/40) to the Polaris provider.

The `polaris_custom_role` resource now enforces, at plan time, that `VIEW_CLUSTER` is granted together with `VIEW_CLUSTER_REFERENCE`. RSC automatically grants `VIEW_CLUSTER_REFERENCE` whenever `VIEW_CLUSTER` is granted, so a configuration listing `VIEW_CLUSTER` alone produced perpetual drift on every plan. A `ValidateConfig` rule now rejects that combination with an actionable error. `VIEW_CLUSTER_REFERENCE` may still be granted on its own, since it is a narrower permission that RSC does not expand.

## Related Issue

None.

## Motivation and Context

Granting `VIEW_CLUSTER` without `VIEW_CLUSTER_REFERENCE` left affected roles in a state that never converged: each `terraform plan` reported the auto-granted `VIEW_CLUSTER_REFERENCE` as a diff. Catching this at plan time prevents the drift and tells the user exactly how to fix their configuration. This mirrors the fix already merged in the rubrik provider so the two providers stay in sync.

## How Has This Been Tested?

`go build`, `go vet`, `gofmt`, and `go generate` (no stray doc diff) are clean, and the unit test `TestValidateCustomRoleConfig` passes.

The affected acceptance tests were run against an RSC deployment (`TF_ACC=1`). All tests related to this change passed, including the new cases:

* `TestAccCustomRoleResource_ViewClusterOnly` — a role granting `VIEW_CLUSTER` without `VIEW_CLUSTER_REFERENCE` is rejected at plan time (`ExpectError`).
* `TestAccCustomRoleResource_ViewClusterReferenceOnly` — `VIEW_CLUSTER_REFERENCE` on its own applies cleanly with no drift.
* `TestAccCustomRoleResource` (+ `_FrameworkMigration`), `TestAccCustomRoleListResource`, `TestAccRoleAssignmentResource` (+ `_FrameworkMigration`), `TestAccRoleDataSource` (+ `_FrameworkMigration`), and the `TestAccUser*` resource/data-source/list tests (which exercise the updated role fixtures).

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Other (please describe in the Description above)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed. (One unrelated test, `TestAccCustomRoleResource_FromTemplate`, fails in the test org because the `Compliance Auditor` role template is absent — see testing notes above.)
