### PR TITLE
Release v1.8.2: fix data center archival cloud compute settings

### DIFF
--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -4,11 +4,14 @@ page_title: "Changelog"
 
 # Changelog
 
-## v1.9.0
+## v1.8.2
 * **Breaking Change:** The `polaris_custom_role` resource now requires the `VIEW_CLUSTER_REFERENCE` permission
   operation to be granted alongside `VIEW_CLUSTER`. RSC automatically adds `VIEW_CLUSTER_REFERENCE` whenever
   `VIEW_CLUSTER` is granted, so granting `VIEW_CLUSTER` alone resulted in perpetual drift. `VIEW_CLUSTER_REFERENCE`
-  may still be granted on its own. See the [v1.9.0 upgrade guide](upgrade_guide_v1.9.0.md).
+  may still be granted on its own. See the [v1.8.2 upgrade guide](upgrade_guide_v1.8.2.md).
+* Fix a bug in the `polaris_data_center_archival_location_amazon_s3` resource where the `cloud_compute_settings`
+  block was read from the `archival_proxy_settings` configuration. Specifying an `archival_proxy_settings` block
+  caused the provider to crash, and any `cloud_compute_settings` values were silently ignored.
 
 ## v1.8.1
 * Add support for the `SERVERS_AND_APPS` feature in the `polaris_gcp_project` resource and the `polaris_gcp_project`

--- a/docs/guides/upgrade_guide_v1.8.2.md
+++ b/docs/guides/upgrade_guide_v1.8.2.md
@@ -1,10 +1,10 @@
 ---
-page_title: "Upgrade Guide: v1.9.0"
+page_title: "Upgrade Guide: v1.8.2"
 ---
 
-# Upgrade Guide v1.9.0
+# Upgrade Guide v1.8.2
 
-The v1.9.0 release adds a plan-time validation to the `polaris_custom_role` resource: a role that grants the
+The v1.8.2 release adds a plan-time validation to the `polaris_custom_role` resource: a role that grants the
 `VIEW_CLUSTER` operation must now also grant `VIEW_CLUSTER_REFERENCE`. See the [changelog](changelog.md) for the full
 list of changes.
 
@@ -21,12 +21,12 @@ Terraform's `moved {}` block, making the switch progressively simpler. See the
 [latest upgrade guide for the rubrikinc/rubrik provider](https://registry.terraform.io/providers/rubrikinc/rubrik/latest/docs/guides)
 for the currently available migration paths.
 
-~> **Note:** If you are upgrading across multiple minor versions (e.g. v1.7.x to v1.9.0), review the upgrade guide for
+~> **Note:** If you are upgrading across multiple minor versions (e.g. v1.7.x to v1.8.2), review the upgrade guide for
 each intermediate version as well. Each guide documents breaking changes and migration steps specific to that release.
 
 ## How to Upgrade
 
-Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.9.0 release. One
+Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.8.2 release. One
 way of doing this is by using the pessimistic constraint operator `~>`, which allows Terraform to upgrade to the latest
 release within the same minor version:
 ```terraform
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     polaris = {
       source  = "rubrikinc/polaris"
-      version = "~> 1.9.0"
+      version = "~> 1.8.2"
     }
   }
 }
@@ -52,7 +52,7 @@ Otherwise, proceed by running:
 ```shell
 % terraform apply -refresh-only
 ```
-This will read the remote state of the resources and migrate the local Terraform state to the v1.9.0 version.
+This will read the remote state of the resources and migrate the local Terraform state to the v1.8.2 version.
 
 ## Significant Changes
 

--- a/internal/provider/resource_data_center_archival_location_amazon_s3.go
+++ b/internal/provider/resource_data_center_archival_location_amazon_s3.go
@@ -556,7 +556,7 @@ func toArchivalProxySettings(target gqlarchival.AWSTarget) []any {
 // fromCloudComputeSettings extracts the cloud compute settings data from the
 // resource configuration.
 func fromCloudComputeSettings(d *schema.ResourceData) (*gqlarchival.AWSTargetCloudComputeSettings, bool) {
-	data, ok := d.GetOk(keyArchivalProxySettings)
+	data, ok := d.GetOk(keyCloudComputeSettings)
 	if !ok {
 		return nil, false
 	}

--- a/internal/provider/resource_data_center_archival_location_amazon_s3_test.go
+++ b/internal/provider/resource_data_center_archival_location_amazon_s3_test.go
@@ -1,0 +1,98 @@
+// Copyright 2024 Rubrik, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+// DEALINGS IN THE SOFTWARE.
+
+package provider
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// TestFromCloudComputeSettings verifies that fromCloudComputeSettings reads the
+// cloud_compute_settings block rather than archival_proxy_settings. Configuring
+// both blocks previously caused a nil interface conversion panic because the
+// function read the proxy block, which has no vpc_id/subnet_id/security_group_id
+// keys.
+func TestFromCloudComputeSettings(t *testing.T) {
+	res := resourceDataCenterArchivalLocationAmazonS3()
+
+	// Both blocks set: the proxy block must not be mistaken for the compute
+	// block.
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]any{
+		keyArchivalProxySettings: []any{
+			map[string]any{
+				keyProxyServer: "10.0.0.1",
+				keyProtocol:    "HTTPS",
+				keyPortNumber:  8080,
+				keyUsername:    "proxyuser",
+				keyPassword:    "proxypass",
+			},
+		},
+		keyCloudComputeSettings: []any{
+			map[string]any{
+				keyVPCID:                 "vpc-12345678",
+				keySubnetID:              "subnet-12345678",
+				keySecurityGroupID:       "sg-12345678",
+				keyArchivalConsolidation: true,
+			},
+		},
+	})
+
+	settings, consolidation := fromCloudComputeSettings(d)
+	if settings == nil {
+		t.Fatal("expected non-nil cloud compute settings")
+	}
+	if got, want := settings.VPCID, "vpc-12345678"; got != want {
+		t.Errorf("VPCID = %q, want %q", got, want)
+	}
+	if got, want := settings.SubnetID, "subnet-12345678"; got != want {
+		t.Errorf("SubnetID = %q, want %q", got, want)
+	}
+	if got, want := settings.SecurityGroupID, "sg-12345678"; got != want {
+		t.Errorf("SecurityGroupID = %q, want %q", got, want)
+	}
+	if !consolidation {
+		t.Error("archival consolidation = false, want true")
+	}
+}
+
+// TestFromCloudComputeSettingsUnset verifies that when no cloud_compute_settings
+// block is configured the function reports it as unset, even if an
+// archival_proxy_settings block is present.
+func TestFromCloudComputeSettingsUnset(t *testing.T) {
+	res := resourceDataCenterArchivalLocationAmazonS3()
+
+	d := schema.TestResourceDataRaw(t, res.Schema, map[string]any{
+		keyArchivalProxySettings: []any{
+			map[string]any{
+				keyProxyServer: "10.0.0.1",
+				keyProtocol:    "HTTPS",
+				keyPortNumber:  8080,
+				keyUsername:    "proxyuser",
+				keyPassword:    "proxypass",
+			},
+		},
+	})
+
+	if settings, _ := fromCloudComputeSettings(d); settings != nil {
+		t.Errorf("expected nil cloud compute settings, got %+v", settings)
+	}
+}

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -4,11 +4,14 @@ page_title: "Changelog"
 
 # Changelog
 
-## v1.9.0
+## v1.8.2
 * **Breaking Change:** The `polaris_custom_role` resource now requires the `VIEW_CLUSTER_REFERENCE` permission
   operation to be granted alongside `VIEW_CLUSTER`. RSC automatically adds `VIEW_CLUSTER_REFERENCE` whenever
   `VIEW_CLUSTER` is granted, so granting `VIEW_CLUSTER` alone resulted in perpetual drift. `VIEW_CLUSTER_REFERENCE`
-  may still be granted on its own. See the [v1.9.0 upgrade guide](upgrade_guide_v1.9.0.md).
+  may still be granted on its own. See the [v1.8.2 upgrade guide](upgrade_guide_v1.8.2.md).
+* Fix a bug in the `polaris_data_center_archival_location_amazon_s3` resource where the `cloud_compute_settings`
+  block was read from the `archival_proxy_settings` configuration. Specifying an `archival_proxy_settings` block
+  caused the provider to crash, and any `cloud_compute_settings` values were silently ignored.
 
 ## v1.8.1
 * Add support for the `SERVERS_AND_APPS` feature in the `polaris_gcp_project` resource and the `polaris_gcp_project`

--- a/templates/guides/upgrade_guide_v1.8.2.md.tmpl
+++ b/templates/guides/upgrade_guide_v1.8.2.md.tmpl
@@ -1,10 +1,10 @@
 ---
-page_title: "Upgrade Guide: v1.9.0"
+page_title: "Upgrade Guide: v1.8.2"
 ---
 
-# Upgrade Guide v1.9.0
+# Upgrade Guide v1.8.2
 
-The v1.9.0 release adds a plan-time validation to the `polaris_custom_role` resource: a role that grants the
+The v1.8.2 release adds a plan-time validation to the `polaris_custom_role` resource: a role that grants the
 `VIEW_CLUSTER` operation must now also grant `VIEW_CLUSTER_REFERENCE`. See the [changelog](changelog.md) for the full
 list of changes.
 
@@ -21,12 +21,12 @@ Terraform's `moved {}` block, making the switch progressively simpler. See the
 [latest upgrade guide for the rubrikinc/rubrik provider](https://registry.terraform.io/providers/rubrikinc/rubrik/latest/docs/guides)
 for the currently available migration paths.
 
-~> **Note:** If you are upgrading across multiple minor versions (e.g. v1.7.x to v1.9.0), review the upgrade guide for
+~> **Note:** If you are upgrading across multiple minor versions (e.g. v1.7.x to v1.8.2), review the upgrade guide for
 each intermediate version as well. Each guide documents breaking changes and migration steps specific to that release.
 
 ## How to Upgrade
 
-Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.9.0 release. One
+Make sure that the `version` field is configured in a way which allows Terraform to upgrade to the v1.8.2 release. One
 way of doing this is by using the pessimistic constraint operator `~>`, which allows Terraform to upgrade to the latest
 release within the same minor version:
 ```terraform
@@ -34,7 +34,7 @@ terraform {
   required_providers {
     polaris = {
       source  = "rubrikinc/polaris"
-      version = "~> 1.9.0"
+      version = "~> 1.8.2"
     }
   }
 }
@@ -52,7 +52,7 @@ Otherwise, proceed by running:
 ```shell
 % terraform apply -refresh-only
 ```
-This will read the remote state of the resources and migrate the local Terraform state to the v1.9.0 version.
+This will read the remote state of the resources and migrate the local Terraform state to the v1.8.2 version.
 
 ## Significant Changes
 


### PR DESCRIPTION
## Summary

Cuts a **v1.8.2** patch release.

### Bug fix
`fromCloudComputeSettings` read the `archival_proxy_settings` block instead of `cloud_compute_settings` in the `polaris_data_center_archival_location_amazon_s3` resource. Specifying an `archival_proxy_settings` block caused the provider to crash on apply:

```
panic: interface conversion: interface {} is nil, not string
... fromCloudComputeSettings(...):566
```

and any `cloud_compute_settings` values were silently ignored. The fix reads the correct block; a unit test reproduces the exact panic without the fix and is wired into the default (untagged) test suite.

### Release packaging
- Renamed the pending `## v1.9.0` changelog section to `## v1.8.2` (the `VIEW_CLUSTER_REFERENCE` breaking change ships in this patch) and added the archival fix entry.
- Renamed `upgrade_guide_v1.9.0.md.tmpl` → `upgrade_guide_v1.8.2.md.tmpl` and re-pointed version pins to `~> 1.8.2`.
- Regenerated docs via `go generate`.

The unmerged GCP `SERVERS_AND_APPS` feature work is unaffected and stays for a future release.

### Checks
`go build`, `go vet`, `gofmt`, and `go test ./internal/provider/` all pass.

> Note: `VIEW_CLUSTER_REFERENCE` is labeled a breaking change shipping in a patch — intentional per maintainer direction.