### PR TITLE
Fix polaris_objects to translate Azure subscription IDs

### DIFF
--- a/internal/provider/framework_data_source_objects.go
+++ b/internal/provider/framework_data_source_objects.go
@@ -152,19 +152,46 @@ func (d *objectsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 	objectType := config.ObjectType.ValueString()
 	subIDStr := config.SubscriptionID.ValueString()
 
+	azureAPI := azure.Wrap(polarisClient)
+
+	// Both the azureNativeResourceGroups filter and each resource group's
+	// azureSubscriptionDetails.id use the native subscription FID, whereas the
+	// data source's subscription_id (input and output) is the RSC cloud account
+	// ID. List the native subscriptions once to translate between the two.
+	natives, err := azureAPI.NativeSubscriptions(ctx, "")
+	if err != nil {
+		res.Diagnostics.AddError("Failed to list Azure native subscriptions", err.Error())
+		return
+	}
+	fidByCloudAccount := make(map[uuid.UUID]uuid.UUID, len(natives))
+	cloudAccountByFID := make(map[string]string, len(natives))
+	for _, n := range natives {
+		fidByCloudAccount[n.CloudAccountID] = n.ID
+		cloudAccountByFID[n.ID.String()] = n.CloudAccountID.String()
+	}
+
 	var subIDs []uuid.UUID
 	if subIDStr != "" {
-		subID, err := uuid.Parse(subIDStr)
+		cloudAccountID, err := uuid.Parse(subIDStr)
 		if err != nil {
 			res.Diagnostics.AddError("Invalid subscription_id", err.Error())
 			return
 		}
-		subIDs = []uuid.UUID{subID}
+
+		// The filter matches on the native subscription FID, so translate the
+		// cloud account ID to its FID before scoping the lookup.
+		fid, ok := fidByCloudAccount[cloudAccountID]
+		if !ok {
+			res.Diagnostics.AddError("Unknown subscription_id",
+				fmt.Sprintf("no Azure native subscription found for RSC cloud account ID %s", cloudAccountID))
+			return
+		}
+		subIDs = []uuid.UUID{fid}
 	}
 
 	// Passing an empty nameSubstring disables the RSC substring filter, so
 	// every resource group in scope is returned.
-	rgs, err := azure.Wrap(polarisClient).NativeResourceGroups(ctx, subIDs, "")
+	rgs, err := azureAPI.NativeResourceGroups(ctx, subIDs, "")
 	if err != nil {
 		res.Diagnostics.AddError("Failed to read Azure native resource groups", err.Error())
 		return
@@ -180,14 +207,24 @@ func (d *objectsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 
 	objectValues := make([]attr.Value, 0, len(rgs))
 	for _, rg := range rgs {
+		// azureSubscriptionDetails.id is the native subscription FID; map it
+		// back to the RSC cloud account ID so the output subscription_id matches
+		// the input and polaris_azure_subscription.id. Fall back to the raw
+		// value if the subscription is somehow not in the native subscription
+		// list.
+		subID := rg.Subscription.ID
+		if cloudAccount, ok := cloudAccountByFID[rg.Subscription.ID]; ok {
+			subID = cloudAccount
+		}
+
 		hash.Write([]byte(rg.ID))
 		hash.Write([]byte(rg.Name))
-		hash.Write([]byte(rg.Subscription.ID))
+		hash.Write([]byte(subID))
 
 		objectValue, diags := types.ObjectValue(objectAttrTypes(), map[string]attr.Value{
 			keyID:             types.StringValue(rg.ID),
 			keyName:           types.StringValue(rg.Name),
-			keySubscriptionID: types.StringValue(rg.Subscription.ID),
+			keySubscriptionID: types.StringValue(subID),
 		})
 		res.Diagnostics.Append(diags...)
 		if res.Diagnostics.HasError() {


### PR DESCRIPTION
## Summary

The `polaris_objects` data source (object type `AzureNativeResourceGroup`) returned no resource groups when scoped with `subscription_id`, and reported the wrong `subscription_id` on returned objects. Same fix as terraform-provider-rubrik#52.

## Root cause

RSC's `azureNativeResourceGroups` filter — and each resource group's `azureSubscriptionDetails.id` — use the **native subscription FID**, whereas the data source's `subscription_id` (both input and output) is the **RSC cloud account ID** (matching `polaris_azure_subscription.id`). Passing the cloud account ID as the filter silently returned an empty result; the output `subscription_id` was the native FID rather than the documented cloud account ID.

## Fix

Resolve the native subscriptions once and translate both directions:
- input cloud account ID → native FID for the query filter
- native FID → cloud account ID for the returned objects, so `subscription_id` round-trips and matches the documented contract

## Testing

Manual `terraform apply` against dev-016 (subscription TrinityTPM): scoped and unscoped `polaris_objects` reads both return 140 resource groups; the target RG reports `subscription_id` equal to the RSC cloud account ID (round-trips). Verified alongside the equivalent `rubrik_objects` data source in the same run.

No changelog entry: the `polaris_objects` data source is unreleased (new in v1.9.0), so the existing "new data source" entry already covers it and now describes correct behavior.