### PR TITLE
Run Azure SQL SLA acceptance tests via the default service account

### DIFF
--- a/internal/provider/resource_sla_domain_azure_sql_test.go
+++ b/internal/provider/resource_sla_domain_azure_sql_test.go
@@ -35,13 +35,8 @@ import (
 func requireAzureSQLSLARevampFeatureFlag(t *testing.T) {
 	t.Helper()
 
-	credentials := os.Getenv("RUBRIK_POLARIS_SERVICEACCOUNT_FILE")
-	if credentials == "" {
-		t.Skip("RUBRIK_POLARIS_SERVICEACCOUNT_FILE not set")
-	}
-
 	ctx := context.Background()
-	c, err := newClient(ctx, credentials, polaris.CacheParams{})
+	c, err := newClient(ctx, "", polaris.CacheParams{})
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -61,9 +56,6 @@ type azureSQLTestResource struct {
 
 func azureSQLTestConfig(resource azureSQLTestResource) testConfig {
 	return testConfig{
-		Provider: struct{ Credentials string }{
-			Credentials: os.Getenv("RUBRIK_POLARIS_SERVICEACCOUNT_FILE"),
-		},
 		Resource: resource,
 	}
 }
@@ -71,9 +63,7 @@ func azureSQLTestConfig(resource azureSQLTestResource) testConfig {
 // V1 (Azure-managed, long-term retention) Azure SQL Database SLA — carries
 // ltr_config, and no Rubrik snapshot schedule or backup location.
 const slaDomainAzureSQLV1Tmpl = `
-provider "polaris" {
-	credentials = "{{ .Provider.Credentials }}"
-}
+provider "polaris" {}
 
 resource "polaris_sla_domain" "azure_sql_v1" {
 	name         = "Test SLA Azure SQL V1"
@@ -107,9 +97,7 @@ data "polaris_sla_domain" "azure_sql_v1" {
 
 // V1 SLA combining the Azure SQL Database and Managed Instance object types.
 const slaDomainAzureSQLDbMiTmpl = `
-provider "polaris" {
-	credentials = "{{ .Provider.Credentials }}"
-}
+provider "polaris" {}
 
 resource "polaris_sla_domain" "azure_sql_db_mi" {
 	name         = "Test SLA Azure SQL DB and MI"
@@ -141,9 +129,7 @@ resource "polaris_sla_domain" "azure_sql_db_mi" {
 // V2 (Rubrik-managed) Azure SQL Database SLA — a snapshot schedule plus a
 // backup location, and no ltr_config.
 const slaDomainAzureSQLV2Tmpl = `
-provider "polaris" {
-	credentials = "{{ .Provider.Credentials }}"
-}
+provider "polaris" {}
 
 resource "polaris_sla_domain" "azure_sql_v2" {
 	name         = "Test SLA Azure SQL V2"


### PR DESCRIPTION
## Summary

The Azure SQL SLA acceptance tests (`TestAccPolarisSLADomain_azureSqlV1`, `TestAccPolarisSLADomain_azureSqlDbMi`, `TestAccPolarisSLADomain_azureSqlV2`) injected the provider `credentials` from `RUBRIK_POLARIS_SERVICEACCOUNT_FILE`. When that variable is unset — the default-service-account convention already used by the newer framework/list acceptance tests — the provider block rendered `credentials = ""`, which the SDKv2 provider rejects:

```
Error: expected "credentials" to not be an empty string or whitespace
  on terraform_plugin_test.tf line 13, in provider "polaris":
  13:     credentials = ""
```

The feature-flag gate also skipped these tests entirely whenever the variable was unset, so they never ran against a default-account setup even when valid credentials were available.

## Changes

- Provider blocks in all three templates now use `provider "polaris" {}` (no injected `credentials`), matching the framework/list test convention.
- `requireAzureSQLSLARevampFeatureFlag` resolves the feature flag via the default service account (`newClient(ctx, "", ...)`) instead of gating on `RUBRIK_POLARIS_SERVICEACCOUNT_FILE`.
- Dropped the now-unused credentials plumbing from `azureSQLTestConfig`.

## Testing

`TF_ACC=1 go test -run TestAccPolarisSLADomain_azureSql ./internal/provider/` against a default RSC service account:

- `TestAccPolarisSLADomain_azureSqlV1` — PASS
- `TestAccPolarisSLADomain_azureSqlDbMi` — PASS
- `TestAccPolarisSLADomain_azureSqlV2` — SKIP (requires `TEST_AZURE_SQL_BACKUP_LOCATION_GROUP_ID`, unchanged)

`go vet` and `gofmt` clean.