### PR TITLE
Bump rubrik-polaris-sdk-for-go to v1.9.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.22.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.8.1-0.20260713155321-7785c7f9fa02
+	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.9.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.22.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.38.1
 	github.com/hashicorp/terraform-plugin-testing v1.14.0
-	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.9.0
+	github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.9.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.9.0 h1:qQgbvm523YM/ms8+1ncFuWr/wlobFLHFeJ4zzbybLfQ=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.9.0/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.9.1 h1:l+u90HbmRjYnrubRH8X4f3e/e8rW+aSwtLm67WPSwn0=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.9.1/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=

--- a/go.sum
+++ b/go.sum
@@ -274,8 +274,8 @@ github.com/posener/complete v1.2.3/go.mod h1:WZIdtGGp+qx0sLrYKtIRAruyNpv6hFCicSg
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.8.1-0.20260713155321-7785c7f9fa02 h1:gY0kizZdtbSoWJH8nwEbGNT+T2IVu4H2M53ccajNlPM=
-github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.8.1-0.20260713155321-7785c7f9fa02/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.9.0 h1:qQgbvm523YM/ms8+1ncFuWr/wlobFLHFeJ4zzbybLfQ=
+github.com/rubrikinc/rubrik-polaris-sdk-for-go v1.9.0/go.mod h1:i+POnzMq5Wpg2mkVVagrBQwtKCJDyYkduRvvi4j4Wec=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=


### PR DESCRIPTION
Pin the SDK dependency to the newly published `v1.9.0` release, replacing the previous pseudo-version.

- Ran `go get github.com/rubrikinc/rubrik-polaris-sdk-for-go@v1.9.0` and `go mod tidy`.
- `go build ./...` passes.