### PR TITLE
Fix Duplicate Set Element error in polaris_objects data source

### DIFF
--- a/internal/provider/framework_data_source_objects.go
+++ b/internal/provider/framework_data_source_objects.go
@@ -201,6 +201,15 @@ func (d *objectsDataSource) Read(ctx context.Context, req datasource.ReadRequest
 		return cmp.Compare(a.ID, b.ID)
 	})
 
+	// RSC's azureNativeResourceGroups connection can return the same resource
+	// group on more than one page, especially while native discovery is still
+	// settling. Drop exact duplicates by object ID before building the Set — the
+	// framework hard-errors on duplicate Set elements. Keyed on ID (not name),
+	// so distinct resource groups that happen to share a name are preserved.
+	rgs = slices.CompactFunc(rgs, func(a, b gqlazure.NativeResourceGroup) bool {
+		return a.ID == b.ID
+	})
+
 	hash := sha256.New()
 	hash.Write([]byte(objectType))
 	hash.Write([]byte(subIDStr))

--- a/internal/provider/framework_data_source_objects_test.go
+++ b/internal/provider/framework_data_source_objects_test.go
@@ -22,6 +22,7 @@ package provider
 
 import (
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/knownvalue"
@@ -29,7 +30,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/tfjsonpath"
 )
 
-const objectsAzureResourceGroupTmpl = `
+// subscriptionOnlyTmpl onboards the Azure subscription alone, with no data
+// sources - used as step 1 so we can insert a real Go-level sleep (PreConfig)
+// before step 2 reads the objects data sources, decoupled from any
+// in-config wait mechanism.
+const subscriptionOnlyTmpl = `
 provider "polaris" {
 	credentials = "{{ .Provider.Credentials }}"
 }
@@ -55,7 +60,9 @@ resource "polaris_azure_subscription" "default" {
 
 	depends_on = [polaris_azure_service_principal.default]
 }
+`
 
+const objectsAzureResourceGroupTmpl = subscriptionOnlyTmpl + `
 data "polaris_objects" "resource_groups" {
 	object_type     = "AzureNativeResourceGroup"
 	subscription_id = polaris_azure_subscription.default.id
@@ -76,6 +83,10 @@ func TestAccPolarisObjectsDataSource_azureResourceGroup(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	subscriptionOnlyConfig, err := makeTerraformConfig(config, subscriptionOnlyTmpl)
+	if err != nil {
+		t.Fatal(err)
+	}
 	objectsConfig, err := makeTerraformConfig(config, objectsAzureResourceGroupTmpl)
 	if err != nil {
 		t.Fatal(err)
@@ -89,24 +100,35 @@ func TestAccPolarisObjectsDataSource_azureResourceGroup(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: protoV6ProviderFactories,
-		Steps: []resource.TestStep{{
-			Config: objectsConfig,
-			Check: resource.ComposeTestCheckFunc(
-				// Verify the Azure subscription resource was created.
-				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_name", subscription.SubscriptionName),
-				resource.TestCheckResourceAttr("polaris_azure_subscription.default", "cloud_native_protection.0.status", "CONNECTED"),
-			),
-			ConfigStateChecks: []statecheck.StateCheck{
-				// Scoped to the fixture's subscription.
-				statecheck.ExpectKnownValue("data.polaris_objects.resource_groups", tfjsonpath.New(keyID),
-					knownvalue.StringRegexp(sha256Hex)),
-				statecheck.ExpectKnownValue("data.polaris_objects.resource_groups", tfjsonpath.New(keyObjects),
-					resourceGroupCheck),
-
-				// Searching across all subscriptions still finds it.
-				statecheck.ExpectKnownValue("data.polaris_objects.all_subscriptions", tfjsonpath.New(keyObjects),
-					resourceGroupCheck),
+		Steps: []resource.TestStep{
+			{
+				// Onboard the subscription alone first.
+				Config: subscriptionOnlyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("polaris_azure_subscription.default", "subscription_name", subscription.SubscriptionName),
+					resource.TestCheckResourceAttr("polaris_azure_subscription.default", "cloud_native_protection.0.status", "CONNECTED"),
+				),
 			},
-		}},
+			{
+				// Sleep for real wall-clock time before adding the objects
+				// data sources. After a subscription connects, RSC needs to
+				// run native discovery before its resource groups become
+				// visible to azureNativeResourceGroups (~1 minute observed);
+				// wait with margin so the read is not racing discovery.
+				PreConfig: func() { time.Sleep(2 * time.Minute) },
+				Config:    objectsConfig,
+				ConfigStateChecks: []statecheck.StateCheck{
+					// Scoped to the fixture's subscription.
+					statecheck.ExpectKnownValue("data.polaris_objects.resource_groups", tfjsonpath.New(keyID),
+						knownvalue.StringRegexp(sha256Hex)),
+					statecheck.ExpectKnownValue("data.polaris_objects.resource_groups", tfjsonpath.New(keyObjects),
+						resourceGroupCheck),
+
+					// Searching across all subscriptions still finds it.
+					statecheck.ExpectKnownValue("data.polaris_objects.all_subscriptions", tfjsonpath.New(keyObjects),
+						resourceGroupCheck),
+				},
+			},
+		},
 	})
 }


### PR DESCRIPTION
## Summary

RSC's `azureNativeResourceGroups` connection can return the same resource group node on more than one page, especially while native discovery is still settling. The `polaris_objects` data source builds a Terraform Set from the results, and the plugin framework hard-errors on duplicate Set elements, failing the read with `Duplicate Set Element`.

This drops exact duplicates by object ID (after the existing sort) before building the Set. Deduplication is keyed on object ID, **not** name, so distinct resource groups that happen to share a name are preserved as separate Set elements.

## Test fix

The acceptance test is also restructured into two steps with a real wall-clock sleep before reading the data sources, matching the terraform-provider-rubrik test. Reading the resource groups in the same apply that onboards the subscription races RSC native discovery, so the expected resource group was intermittently missing from the results (`SetPartial` "missing value" failures).

## Notes

- The `polaris_objects` data source is new in the unreleased v1.9.0, so no separate changelog entry is added — the fix folds into the existing "New data source" entry.

## Test plan

- `go build ./...`, `go vet ./...`, `gofmt` clean
- Acceptance: `TF_ACC=1 go test -run TestAccPolarisObjectsDataSource_azureResourceGroup ./internal/provider/` (requires RSC creds)