### PR TITLE
Backport: Add AzureSqlManagedInstanceServer object type to the polaris_object data source

### DIFF
--- a/docs/data-sources/object.md
+++ b/docs/data-sources/object.md
@@ -7,12 +7,12 @@ description: |-
   name and type. This is useful for finding the ID of an object when only its
   name and type are known.
   Supported object types:
-  AwsNativeAccount - AWS Native AccountAwsNativeEbsVolume - AWS Native EBS VolumeAwsNativeEc2Instance - AWS Native EC2 InstanceAwsNativeRdsInstance - AWS Native RDS InstanceAzureDevOpsOrganization - Azure DevOps OrganizationAzureDevOpsProject - Azure DevOps ProjectAzureDevOpsRepository - Azure DevOps RepositoryAzureNativeResourceGroup - Azure Native Resource GroupAzureNativeSubscription - Azure Native SubscriptionAzureNativeVirtualMachine - Azure Native Virtual MachineCloudNativeTagRule - Cloud Native Tag RuleGitHubOrganization - GitHub OrganizationGitHubRepository - GitHub Repository
-  -> Note: Azure resource group names are only unique within a
-  subscription. When a name is shared across subscriptions, set
-  subscription_id to the parent subscription's RSC cloud account ID to
-  disambiguate; otherwise the lookup returns a "multiple objects found"
-  error.
+  AwsNativeAccount - AWS Native AccountAwsNativeEbsVolume - AWS Native EBS VolumeAwsNativeEc2Instance - AWS Native EC2 InstanceAwsNativeRdsInstance - AWS Native RDS InstanceAzureDevOpsOrganization - Azure DevOps OrganizationAzureDevOpsProject - Azure DevOps ProjectAzureDevOpsRepository - Azure DevOps RepositoryAzureNativeResourceGroup - Azure Native Resource GroupAzureNativeSubscription - Azure Native SubscriptionAzureNativeVirtualMachine - Azure Native Virtual MachineAzureSqlManagedInstanceServer - Azure SQL Managed Instance ServerCloudNativeTagRule - Cloud Native Tag RuleGitHubOrganization - GitHub OrganizationGitHubRepository - GitHub Repository
+  -> Note: Azure resource group and SQL Managed Instance server names are
+  only unique within a subscription. When a name is shared across
+  subscriptions, set subscription_id to the parent subscription's RSC cloud
+  account ID to disambiguate; otherwise the lookup returns a "multiple objects
+  found" error.
   -> Note: Azure DevOps project and repository names, and GitHub repository
   names, are only unique within their parent. When a name is shared across
   parents, set org_id (for AzureDevOpsProject or GitHubRepository)
@@ -37,15 +37,16 @@ Supported object types:
   * `AzureNativeResourceGroup` - Azure Native Resource Group
   * `AzureNativeSubscription` - Azure Native Subscription
   * `AzureNativeVirtualMachine` - Azure Native Virtual Machine
+  * `AzureSqlManagedInstanceServer` - Azure SQL Managed Instance Server
   * `CloudNativeTagRule` - Cloud Native Tag Rule
   * `GitHubOrganization` - GitHub Organization
   * `GitHubRepository` - GitHub Repository
 
--> **Note:** Azure resource group names are only unique within a
-subscription. When a name is shared across subscriptions, set
-`subscription_id` to the parent subscription's RSC cloud account ID to
-disambiguate; otherwise the lookup returns a "multiple objects found"
-error.
+-> **Note:** Azure resource group and SQL Managed Instance server names are
+only unique within a subscription. When a name is shared across
+subscriptions, set `subscription_id` to the parent subscription's RSC cloud
+account ID to disambiguate; otherwise the lookup returns a "multiple objects
+found" error.
 
 -> **Note:** Azure DevOps project and repository names, and GitHub repository
 names, are only unique within their parent. When a name is shared across
@@ -85,13 +86,13 @@ data "polaris_object" "project" {
 ### Required
 
 - `name` (String) Exact object name to search for.
-- `object_type` (String) Object type. Possible values are `AwsNativeAccount`, `AwsNativeEbsVolume`, `AwsNativeEc2Instance`, `AwsNativeRdsInstance`, `AzureDevOpsOrganization`, `AzureDevOpsProject`, `AzureDevOpsRepository`, `AzureNativeResourceGroup`, `AzureNativeSubscription`, `AzureNativeVirtualMachine`, `CloudNativeTagRule`, `GitHubOrganization` and `GitHubRepository`.
+- `object_type` (String) Object type. Possible values are `AwsNativeAccount`, `AwsNativeEbsVolume`, `AwsNativeEc2Instance`, `AwsNativeRdsInstance`, `AzureDevOpsOrganization`, `AzureDevOpsProject`, `AzureDevOpsRepository`, `AzureNativeResourceGroup`, `AzureNativeSubscription`, `AzureNativeVirtualMachine`, `AzureSqlManagedInstanceServer`, `CloudNativeTagRule`, `GitHubOrganization` and `GitHubRepository`.
 
 ### Optional
 
 - `org_id` (String) RSC object ID of the parent organization (UUID). May be set when `object_type` is `AzureDevOpsProject` to disambiguate a project name shared across organizations, when `object_type` is `AzureDevOpsRepository` to disambiguate a repository name shared across projects, or when `object_type` is `GitHubRepository` to disambiguate a repository name shared across organizations; must not be set for other object types.
 - `project_id` (String) RSC object ID of the parent Azure DevOps project (UUID). May be set when `object_type` is `AzureDevOpsRepository` to disambiguate a repository name shared across projects; must not be set for other object types.
-- `subscription_id` (String) RSC cloud account ID of the parent Azure subscription (UUID). May be set when `object_type` is `AzureNativeResourceGroup`; must not be set for other object types.
+- `subscription_id` (String) RSC cloud account ID of the parent Azure subscription (UUID). May be set when `object_type` is `AzureNativeResourceGroup` or `AzureSqlManagedInstanceServer` to disambiguate a name shared across subscriptions; must not be set for other object types.
 - `timeouts` (Attributes) (see [below for nested schema](#nestedatt--timeouts))
 
 ### Read-Only

--- a/docs/guides/changelog.md
+++ b/docs/guides/changelog.md
@@ -16,6 +16,10 @@ page_title: "Changelog"
 * Add support for the `CloudNativeTagRule` object type in the `polaris_object` data source, resolving a cloud native
   tag rule to its RSC ID by name for use with the `polaris_sla_domain_assignment` resource.
   [[docs](../data-sources/object.md)]
+* Add support for the `AzureSqlManagedInstanceServer` object type in the `polaris_object` data source, resolving an
+  Azure SQL Managed Instance server to its RSC ID by name for use with the `polaris_sla_domain_assignment` resource.
+  Set `subscription_id` to disambiguate a server name shared across subscriptions.
+  [[docs](../data-sources/object.md)]
 * No longer require `subscription_id` when `object_type` is `AzureNativeResourceGroup` in the `polaris_object` data
   source. Set it only to disambiguate a resource group name shared across subscriptions.
   [[docs](../data-sources/object.md)]

--- a/internal/provider/framework_data_source_object.go
+++ b/internal/provider/framework_data_source_object.go
@@ -59,15 +59,16 @@ Supported object types:
   * ´AzureNativeResourceGroup´ - Azure Native Resource Group
   * ´AzureNativeSubscription´ - Azure Native Subscription
   * ´AzureNativeVirtualMachine´ - Azure Native Virtual Machine
+  * ´AzureSqlManagedInstanceServer´ - Azure SQL Managed Instance Server
   * ´CloudNativeTagRule´ - Cloud Native Tag Rule
   * ´GitHubOrganization´ - GitHub Organization
   * ´GitHubRepository´ - GitHub Repository
 
--> **Note:** Azure resource group names are only unique within a
-subscription. When a name is shared across subscriptions, set
-´subscription_id´ to the parent subscription's RSC cloud account ID to
-disambiguate; otherwise the lookup returns a "multiple objects found"
-error.
+-> **Note:** Azure resource group and SQL Managed Instance server names are
+only unique within a subscription. When a name is shared across
+subscriptions, set ´subscription_id´ to the parent subscription's RSC cloud
+account ID to disambiguate; otherwise the lookup returns a "multiple objects
+found" error.
 
 -> **Note:** Azure DevOps project and repository names, and GitHub repository
 names, are only unique within their parent. When a name is shared across
@@ -123,6 +124,7 @@ func (d *objectDataSource) Schema(ctx context.Context, _ datasource.SchemaReques
 		"AzureNativeResourceGroup",
 		"AzureNativeSubscription",
 		"AzureNativeVirtualMachine",
+		"AzureSqlManagedInstanceServer",
 		"CloudNativeTagRule",
 		"GitHubOrganization",
 		"GitHubRepository",
@@ -152,7 +154,8 @@ func (d *objectDataSource) Schema(ctx context.Context, _ datasource.SchemaReques
 			keySubscriptionID: schema.StringAttribute{
 				Optional: true,
 				Description: "RSC cloud account ID of the parent Azure subscription (UUID). May be set when " +
-					"`object_type` is `AzureNativeResourceGroup`; must not be set for other object types.",
+					"`object_type` is `AzureNativeResourceGroup` or `AzureSqlManagedInstanceServer` to " +
+					"disambiguate a name shared across subscriptions; must not be set for other object types.",
 				Validators: []validator.String{
 					isUUID(),
 				},
@@ -229,7 +232,7 @@ func validateObjectConfig(config objectModel) diag.Diagnostics {
 	}{{
 		key:     keySubscriptionID,
 		value:   config.SubscriptionID,
-		allowed: []string{"AzureNativeResourceGroup"},
+		allowed: []string{"AzureNativeResourceGroup", "AzureSqlManagedInstanceServer"},
 	}, {
 		key:     keyOrgID,
 		value:   config.OrgID,
@@ -520,6 +523,25 @@ func (d *objectDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 		}
 
 		for _, r := range results {
+			objects = append(objects, r.Object)
+		}
+	case "AzureSqlManagedInstanceServer":
+		results, err := hierarchy.ObjectsByName[hierarchy.AzureSQLManagedInstanceServer](ctx, api, name, hierarchy.WorkloadAllSubHierarchyType, activeFilters...)
+		if err != nil {
+			res.Diagnostics.AddError("Failed to look up objects", err.Error())
+			return
+		}
+
+		// SQL Managed Instance server names are only unique within a
+		// subscription, and the inventory query has no subscription filter, so
+		// when subscription_id is set, narrow to that subscription client-side.
+		// The node's accountConnectionId is the RSC cloud account ID, so no
+		// native FID translation is needed.
+		subscriptionID := config.SubscriptionID.ValueString()
+		for _, r := range results {
+			if subscriptionID != "" && r.ResourceGroup.Subscription.CloudAccountID.String() != subscriptionID {
+				continue
+			}
 			objects = append(objects, r.Object)
 		}
 	case "CloudNativeTagRule":

--- a/internal/provider/framework_data_source_object_test.go
+++ b/internal/provider/framework_data_source_object_test.go
@@ -188,6 +188,13 @@ func TestValidateObjectConfig(t *testing.T) {
 			},
 		},
 		{
+			name: "SubscriptionIDWithSQLManagedInstanceServer",
+			config: objectModel{
+				ObjectType:     types.StringValue("AzureSqlManagedInstanceServer"),
+				SubscriptionID: types.StringValue("550e8400-e29b-41d4-a716-446655440000"),
+			},
+		},
+		{
 			name: "SubscriptionIDWithWrongType",
 			config: objectModel{
 				ObjectType:     types.StringValue("AwsNativeEc2Instance"),

--- a/templates/guides/changelog.md.tmpl
+++ b/templates/guides/changelog.md.tmpl
@@ -16,6 +16,10 @@ page_title: "Changelog"
 * Add support for the `CloudNativeTagRule` object type in the `polaris_object` data source, resolving a cloud native
   tag rule to its RSC ID by name for use with the `polaris_sla_domain_assignment` resource.
   [[docs](../data-sources/object.md)]
+* Add support for the `AzureSqlManagedInstanceServer` object type in the `polaris_object` data source, resolving an
+  Azure SQL Managed Instance server to its RSC ID by name for use with the `polaris_sla_domain_assignment` resource.
+  Set `subscription_id` to disambiguate a server name shared across subscriptions.
+  [[docs](../data-sources/object.md)]
 * No longer require `subscription_id` when `object_type` is `AzureNativeResourceGroup` in the `polaris_object` data
   source. Set it only to disambiguate a resource group name shared across subscriptions.
   [[docs](../data-sources/object.md)]


### PR DESCRIPTION
## Summary

Backport of rubrikinc/terraform-provider-rubrik#61 to the `polaris_object` data source.

Adds the `AzureSqlManagedInstanceServer` object type, resolving an Azure SQL Managed Instance server to its RSC object ID by name for use with the `polaris_sla_domain_assignment` resource.

> [!IMPORTANT]
> **Re-review requested.** The existing approval predates a substantive rebase: #476 migrated the object data source to the Plugin Framework, so this change moved to a different file. The approval was given against the old SDKv2 implementation.

## Changes

- `internal/provider/framework_data_source_object.go` — register the new object type, add its lookup case, and allow `subscription_id` for it at plan time.
- `internal/provider/framework_data_source_object_test.go` — cover the new `subscription_id` / `object_type` combination in `TestValidateObjectConfig`.
- `templates/guides/changelog.md.tmpl` — changelog entry under v1.9.2.
- `docs/` — regenerated.

## Notes

SQL Managed Instance servers are inventory objects, so they are looked up through the hierarchy inventory query like the other native workload types, rather than a dedicated query. That query has no subscription filter, so `subscription_id` is applied client-side by matching the node's parent subscription. `accountConnectionId` on the node *is* the RSC cloud account ID, so no native FID translation is needed. Server names are only unique within a subscription, so `subscription_id` is accepted for this type at plan time alongside `AzureNativeResourceGroup`.

Rebased onto `main` after #476 (Plugin Framework migration) and #477. Three things changed as a result:

- The change moved from the deleted `internal/provider/data_source_object.go` to `internal/provider/framework_data_source_object.go`, and error reporting switched from `diag.Errorf` to `res.Diagnostics.AddError`.
- #476 deleted the hand-written `templates/data-sources/object.md.tmpl`, so the template edit this PR previously carried is gone — object docs are now generated from the schema.
- No SDK bump is needed any more. `main` already pins an SDK commit that includes `hierarchy.AzureSQLManagedInstanceServer` along with its tenant domain fix, so `go.mod` and `go.sum` are untouched. The earlier warning about not merging before rubrikinc/rubrik-polaris-sdk-for-go#402 no longer applies — that PR has merged.

One behavior change worth flagging: the previous version returned a subscription-specific "no object found in subscription X" error when `subscription_id` filtered out every match. #476 removed that error from the `AzureNativeResourceGroup` path, so this PR drops it too and falls through to the shared "no object found" error, matching how `AzureDevOpsProject` and `GitHubRepository` handle their own client-side filtering. Happy to reinstate the more specific message if preferred.

This stays in lockstep with rubrikinc/terraform-provider-rubrik#61: the two diffs have identical file lists and identical insertion and deletion counts, differing only in the `rubrik_` / `polaris_` naming and the prefix-versus-`ProviderTypeName` registration that already distinguishes the two providers' framework files.

## Testing

- `go build`, `go vet`, `gofmt`, and `go generate` (idempotent) all clean.
- `go test ./internal/...` produces the same 34 failures as `main` and no others. They are all pre-existing acceptance tests that error rather than skip when RSC credentials are absent, unrelated to this change. `TestValidateObjectConfig/SubscriptionIDWithSQLManagedInstanceServer` passes.
- **Live (dev RSC, identifiers omitted):** verified end to end with `terraform apply` before the rebase, against an instance with four SQL Managed Instance servers — exact-name lookup and subscription-scoped lookup both return the expected object ID, matching the rubrik provider's results against the same instance. Not re-run live since the move to the Framework data source.
